### PR TITLE
Use correct artifact id

### DIFF
--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -34,6 +34,13 @@ kotlin {
 }
 
 publishing {
+    publications {
+        create<MavenPublication>("maven") {
+            groupId = "dk.spilpind"
+            artifactId = "sms-core"
+        }
+    }
+
     repositories {
         maven {
             name = "GitHubPackages"


### PR DESCRIPTION
Use correct artifact after we've created library module (it was published as `library` instead of `sms-core`). We don't have to set `groupId` but is good for consistency.