### PR TITLE
Make publications all lowercase

### DIFF
--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -37,10 +37,8 @@ kotlin {
 publishing {
     publications {
         publications.withType<MavenPublication> {
-            artifactId = if (name == "kotlinMultiplatform") {
-                baseArtifactId
-            } else {
-                "$baseArtifactId-$name"
+            if (artifactId.startsWith(project.name, ignoreCase = true)) {
+                artifactId = artifactId.replaceFirst(project.name, baseArtifactId)
             }
         }
     }


### PR DESCRIPTION
#32 did make ios-targets uppercase (wasn't seen locally on my Windows PC). The targets can't be uppercase in the publications (as the existing ones aren't that in Github Packages) - so instead of trying to determine them ourselves we just replace whatever was before.