### PR TITLE
Improve Swift classes prefix

### DIFF
--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -1,7 +1,7 @@
 import java.net.URI
 
 group = "dk.spilpind"
-version = "1.5.2"
+version = "1.5.3"
 val baseArtifactId = "sms-core"
 
 plugins {

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/VersionInfo.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/VersionInfo.kt
@@ -3,4 +3,4 @@ package dk.spilpind.sms
 /**
  * Version of the current SMS core. Useful e.g. when logging what's used
  */
-const val SMS_CORE_VERSION = "1.5.2"
+const val SMS_CORE_VERSION = "1.5.3"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -9,3 +9,10 @@ pluginManagement {
 }
 
 include(":library")
+
+// This name will be used as module name by the generated iOS libraries (and for instance also as
+// name for the generated klibs) and will therefore be used as prefix for the Swift name of the
+// classes available in the swift-projects (when this library is included in a shared KMP module).
+// For instance can the Team interface be referenced as SmsCoreTeam.
+// Conclusion: Don't change this unless we want to change that prefix!
+project(":library").name = "SmsCore"


### PR DESCRIPTION
Change prefix of classes when accessed from Swift as it was automatically set to the name of the module - and having stuff like `LibraryTeam` was a bit odd - `SmsCoreTeam` is much better.

I tried a lot of different things in order to achieve this, for instance using the `-module-name` arg, but that didn't work. Setting base name of framework didn't help either - this was the only thing I found to work.