### PR TITLE
Add start date, end date and locked property to Tournament

### DIFF
--- a/library/src/commonMain/kotlin/dk/spilpind/sms/api/action/TournamentAction.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/api/action/TournamentAction.kt
@@ -2,6 +2,7 @@ package dk.spilpind.sms.api.action
 
 import dk.spilpind.sms.api.common.Action
 import dk.spilpind.sms.core.model.Context
+import kotlinx.datetime.LocalDate
 import kotlinx.serialization.Serializable
 
 /**
@@ -15,7 +16,11 @@ sealed class TournamentAction : ContextAction() {
      * Adds a new tournament. A successful response to this would be [TournamentReaction.Added]
      */
     @Serializable
-    data class Add(val name: String) : TournamentAction() {
+    data class Add(
+        val name: String,
+        val startDate: LocalDate? = null,
+        val endDate: LocalDate? = null
+    ) : TournamentAction() {
         override val action: Action = Action.Add
     }
 

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/api/action/TournamentReaction.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/api/action/TournamentReaction.kt
@@ -64,6 +64,7 @@ sealed class TournamentReaction : ContextReaction() {
         val tournamentId: Int,
         val name: String,
         val isPublic: Boolean,
+        val isLocked: Boolean,
         val tags: List<String>,
         val startDate: LocalDate?,
         val endDate: LocalDate?

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/api/action/TournamentReaction.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/api/action/TournamentReaction.kt
@@ -2,6 +2,7 @@ package dk.spilpind.sms.api.action
 
 import dk.spilpind.sms.core.model.Context
 import dk.spilpind.sms.api.common.Reaction
+import kotlinx.datetime.LocalDate
 import kotlinx.serialization.Serializable
 
 /**
@@ -59,5 +60,12 @@ sealed class TournamentReaction : ContextReaction() {
      * Represents a single tournament
      */
     @Serializable
-    data class Tournament(val tournamentId: Int, val name: String, val isPublic: Boolean, val tags: List<String>)
+    data class Tournament(
+        val tournamentId: Int,
+        val name: String,
+        val isPublic: Boolean,
+        val tags: List<String>,
+        val startDate: LocalDate?,
+        val endDate: LocalDate?
+    )
 }

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/core/Permissions.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/core/Permissions.kt
@@ -162,6 +162,14 @@ object Permissions {
     }
 
     /**
+     * Checks if the user can remove a game in the specified [tournament]. A locked tournament does not allow any
+     * game to be removed
+     */
+    fun User.Privileged.canRemoveGame(tournament: Tournament): Boolean {
+        return !tournament.isLocked && canRemoveGames()
+    }
+
+    /**
      * Checks if the user can edit any game
      */
     fun User.Privileged.canEditGames(): Boolean {
@@ -169,9 +177,20 @@ object Permissions {
     }
 
     /**
-     * Checks if the user can create an invite such that another team can join the [game]
+     * Checks if the user can edit a game in the specified [tournament]. A locked tournament does not allow any
+     * game to be edited
      */
-    fun User.Privileged.canCreateTeamJoinInviteForGame(game: Game): Boolean {
+    fun User.Privileged.canEditGame(tournament: Tournament): Boolean {
+        return !tournament.isLocked && canEditGames()
+    }
+
+    /**
+     * Checks if the user can create an invite such that another team can join the [game] in the specified [tournament]
+     */
+    fun User.Privileged.canCreateTeamJoinInviteForGame(game: Game, tournament: Tournament): Boolean {
+        if (tournament.isLocked) {
+            return false
+        }
         return hasSystemRole(UserRole.ContextRole.System.Admin) ||
                 game.teamAId?.let { teamId ->
                     hasRole(role = UserRole.ContextRole.Team.Captain, contextId = teamId)
@@ -189,10 +208,11 @@ object Permissions {
     }
 
     /**
-     * Checks if the user can add the specified [team] to a game on behalf of the team
+     * Checks if the user can add the specified [team] to a game in the specified [tournament] on behalf of the team
      */
-    fun User.Privileged.canJoinGame(team: Team): Boolean {
-        return hasRole(role = UserRole.ContextRole.Team.Captain, contextId = team.teamId)
+    fun User.Privileged.canJoinGame(team: Team, tournament: Tournament): Boolean {
+        return !tournament.isLocked
+                && hasRole(role = UserRole.ContextRole.Team.Captain, contextId = team.teamId)
     }
 
     /**
@@ -230,9 +250,20 @@ object Permissions {
     }
 
     /**
-     * Checks if the user can edit team associated with [teamId]
+     * Checks if the user can remove a team from the specified [tournament]. A locked tournament does not allow any
+     * team to be removed
      */
-    fun User.Privileged.canEditTeam(teamId: Team.Id): Boolean {
+    fun User.Privileged.canRemoveTeam(tournament: Tournament): Boolean {
+        return !tournament.isLocked && canRemoveTeams()
+    }
+
+    /**
+     * Checks if the user can edit the team associated with [teamId] in the specified [tournament]
+     */
+    fun User.Privileged.canEditTeam(teamId: Team.Id, tournament: Tournament): Boolean {
+        if (tournament.isLocked) {
+            return false
+        }
         return hasSystemRole(UserRole.ContextRole.System.Admin)
                 || hasRole(role = UserRole.ContextRole.Team.Captain, contextId = teamId)
     }

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/core/Permissions.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/core/Permissions.kt
@@ -110,7 +110,7 @@ object Permissions {
     fun User.Privileged?.canViewGame(game: Game, tournament: Tournament): Boolean {
         if (this != null) {
             if (hasSystemRole(UserRole.ContextRole.System.Admin)
-                || canJudgeGame(game = game, tournament = tournament)
+                || hasRole(UserRole.ContextRole.Game.Referee, contextId = game.gameId)
             ) {
                 return true
             }

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/core/Permissions.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/core/Permissions.kt
@@ -97,6 +97,13 @@ object Permissions {
     }
 
     /**
+     * Checks if the user can remove the specified [tournament]. A locked tournament can never be removed
+     */
+    fun User.Privileged.canRemoveTournament(tournament: Tournament): Boolean {
+        return !tournament.isLocked && canRemoveTournaments()
+    }
+
+    /**
      * Checks if the user (or "everyone" if null) can view the specified [game] when associated with the specified
      * [tournament]
      */
@@ -136,7 +143,9 @@ object Permissions {
      * Checks if the user can add a game with the specified [tournament] and set of [teams]
      */
     fun User.Privileged.canAddGame(tournament: Tournament, teams: List<Team>): Boolean {
-        return if (canAddGames()) {
+        return if (tournament.isLocked) {
+            false
+        } else if (canAddGames()) {
             true
         } else if (tournament.isCurrentStickLeague && teams.size == 1) {
             hasRole(role = UserRole.ContextRole.Team.Captain, contextId = teams.first().teamId)
@@ -176,7 +185,7 @@ object Permissions {
      * Checks if the user can create an invite such that another user can become a referee of the [game]
      */
     fun User.Privileged.canCreateRefereeInviteForGame(game: Game, tournament: Tournament): Boolean {
-        return canJudgeGame(game = game, tournament = tournament)
+        return !tournament.isLocked && canJudgeGame(game = game, tournament = tournament)
     }
 
     /**
@@ -210,7 +219,7 @@ object Permissions {
      * Checks if the user can add teams with the specified [tournament]
      */
     fun User.Privileged.canAddTeam(tournament: Tournament): Boolean {
-        return canAddTeams() || tournament.isCurrentStickLeague
+        return !tournament.isLocked && (canAddTeams() || tournament.isCurrentStickLeague)
     }
 
     /**
@@ -249,7 +258,9 @@ object Permissions {
     }
 
     fun User.Privileged.canJudgeGame(game: Game, tournament: Tournament): Boolean {
-        return if (
+        return if (tournament.isLocked) {
+            false
+        } else if (
             hasSystemRole(UserRole.ContextRole.System.Admin)
             || hasRole(UserRole.ContextRole.Game.Referee, contextId = game.gameId)
         ) {

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/core/Permissions.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/core/Permissions.kt
@@ -90,17 +90,10 @@ object Permissions {
     }
 
     /**
-     * Checks if the user can remove any tournament
-     */
-    fun User.Privileged.canRemoveTournaments(): Boolean {
-        return hasSystemRole(UserRole.ContextRole.System.Admin)
-    }
-
-    /**
      * Checks if the user can remove the specified [tournament]. A locked tournament can never be removed
      */
     fun User.Privileged.canRemoveTournament(tournament: Tournament): Boolean {
-        return !tournament.isLocked && canRemoveTournaments()
+        return !tournament.isLocked && hasSystemRole(UserRole.ContextRole.System.Admin)
     }
 
     /**
@@ -133,19 +126,12 @@ object Permissions {
     }
 
     /**
-     * Checks if the user can add any kind of game
-     */
-    fun User.Privileged.canAddGames(): Boolean {
-        return hasSystemRole(UserRole.ContextRole.System.Admin)
-    }
-
-    /**
      * Checks if the user can add a game with the specified [tournament] and set of [teams]
      */
     fun User.Privileged.canAddGame(tournament: Tournament, teams: List<Team>): Boolean {
         return if (tournament.isLocked) {
             false
-        } else if (canAddGames()) {
+        } else if (hasSystemRole(UserRole.ContextRole.System.Admin)) {
             true
         } else if (tournament.isCurrentStickLeague && teams.size == 1) {
             hasRole(role = UserRole.ContextRole.Team.Captain, contextId = teams.first().teamId)
@@ -155,25 +141,11 @@ object Permissions {
     }
 
     /**
-     * Checks if the user can remove any game
-     */
-    fun User.Privileged.canRemoveGames(): Boolean {
-        return hasSystemRole(UserRole.ContextRole.System.Admin)
-    }
-
-    /**
      * Checks if the user can remove a game in the specified [tournament]. A locked tournament does not allow any
      * game to be removed
      */
     fun User.Privileged.canRemoveGame(tournament: Tournament): Boolean {
-        return !tournament.isLocked && canRemoveGames()
-    }
-
-    /**
-     * Checks if the user can edit any game
-     */
-    fun User.Privileged.canEditGames(): Boolean {
-        return hasSystemRole(UserRole.ContextRole.System.Admin)
+        return !tournament.isLocked && hasSystemRole(UserRole.ContextRole.System.Admin)
     }
 
     /**
@@ -181,7 +153,7 @@ object Permissions {
      * game to be edited
      */
     fun User.Privileged.canEditGame(tournament: Tournament): Boolean {
-        return !tournament.isLocked && canEditGames()
+        return !tournament.isLocked && hasSystemRole(UserRole.ContextRole.System.Admin)
     }
 
     /**
@@ -228,25 +200,11 @@ object Permissions {
     }
 
     /**
-     * Checks if the user can add any kind of team
-     */
-    fun User.Privileged.canAddTeams(): Boolean {
-        return hasSystemRole(UserRole.ContextRole.System.Admin)
-    }
-
-
-    /**
      * Checks if the user can add teams with the specified [tournament]
      */
     fun User.Privileged.canAddTeam(tournament: Tournament): Boolean {
-        return !tournament.isLocked && (canAddTeams() || tournament.isCurrentStickLeague)
-    }
-
-    /**
-     * Checks if the user can remove any team
-     */
-    fun User.Privileged.canRemoveTeams(): Boolean {
-        return hasSystemRole(UserRole.ContextRole.System.Admin)
+        return !tournament.isLocked
+                && (hasSystemRole(UserRole.ContextRole.System.Admin) || tournament.isCurrentStickLeague)
     }
 
     /**
@@ -254,7 +212,7 @@ object Permissions {
      * team to be removed
      */
     fun User.Privileged.canRemoveTeam(tournament: Tournament): Boolean {
-        return !tournament.isLocked && canRemoveTeams()
+        return !tournament.isLocked && hasSystemRole(UserRole.ContextRole.System.Admin)
     }
 
     /**

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/core/Permissions.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/core/Permissions.kt
@@ -90,7 +90,7 @@ object Permissions {
     }
 
     /**
-     * Checks if the user can remove the specified [tournament]. A locked tournament can never be removed
+     * Checks if the user can remove the specified [tournament]
      */
     fun User.Privileged.canRemoveTournament(tournament: Tournament): Boolean {
         return !tournament.isLocked && hasSystemRole(UserRole.ContextRole.System.Admin)
@@ -141,16 +141,14 @@ object Permissions {
     }
 
     /**
-     * Checks if the user can remove a game in the specified [tournament]. A locked tournament does not allow any
-     * game to be removed
+     * Checks if the user can remove a game in the specified [tournament]
      */
     fun User.Privileged.canRemoveGame(tournament: Tournament): Boolean {
         return !tournament.isLocked && hasSystemRole(UserRole.ContextRole.System.Admin)
     }
 
     /**
-     * Checks if the user can edit a game in the specified [tournament]. A locked tournament does not allow any
-     * game to be edited
+     * Checks if the user can edit a game in the specified [tournament]
      */
     fun User.Privileged.canEditGame(tournament: Tournament): Boolean {
         return !tournament.isLocked && hasSystemRole(UserRole.ContextRole.System.Admin)
@@ -208,8 +206,7 @@ object Permissions {
     }
 
     /**
-     * Checks if the user can remove a team from the specified [tournament]. A locked tournament does not allow any
-     * team to be removed
+     * Checks if the user can remove a team from the specified [tournament]
      */
     fun User.Privileged.canRemoveTeam(tournament: Tournament): Boolean {
         return !tournament.isLocked && hasSystemRole(UserRole.ContextRole.System.Admin)

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/core/Permissions.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/core/Permissions.kt
@@ -201,8 +201,10 @@ object Permissions {
      * Checks if the user can add teams with the specified [tournament]
      */
     fun User.Privileged.canAddTeam(tournament: Tournament): Boolean {
-        return !tournament.isLocked
-                && (hasSystemRole(UserRole.ContextRole.System.Admin) || tournament.isCurrentStickLeague)
+        if (tournament.isLocked) {
+            return false
+        }
+        return hasSystemRole(UserRole.ContextRole.System.Admin) || tournament.isCurrentStickLeague
     }
 
     /**

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/Tournament.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/Tournament.kt
@@ -10,6 +10,7 @@ data class Tournament(
     val tournamentId: Id,
     val name: String,
     val isPublic: Boolean,
+    val isLocked: Boolean,
     val tags: List<String>,
     val startDate: LocalDate?,
     val endDate: LocalDate?

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/Tournament.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/Tournament.kt
@@ -1,11 +1,19 @@
 package dk.spilpind.sms.core.model
 
+import kotlinx.datetime.LocalDate
 import kotlin.jvm.JvmInline
 
 /**
  * Represents data about a tournament
  */
-data class Tournament(val tournamentId: Id, val name: String, val isPublic: Boolean, val tags: List<String>) {
+data class Tournament(
+    val tournamentId: Id,
+    val name: String,
+    val isPublic: Boolean,
+    val tags: List<String>,
+    val startDate: LocalDate?,
+    val endDate: LocalDate?
+) {
 
     /**
      * Id of a tournament. Can be used to reference a tournament without having to care about the tournament game data


### PR DESCRIPTION
## Summary

Adds two new tournament features and tightens the permission layer accordingly.

### 1. Tournament dates

- New optional `startDate: LocalDate?` and `endDate: LocalDate?` on:
  - `core.model.Tournament`
  - `api.action.TournamentReaction.Tournament` (returned in reactions)
  - `api.action.TournamentAction.Add` (optional, default `null` — backwards compatible for existing callers)
- Uses `kotlinx.datetime.LocalDate`, picked over `LocalDateTime` because tournament scheduling is naturally calendar-day-shaped. The wider codebase otherwise uses `LocalDateTime`; this is the first `LocalDate`.

### 2. Tournament `isLocked` flag

A locked tournament is fully immutable: nothing about it, or anything belonging to it, can be altered or deleted by anyone (including admins).

- New `isLocked: Boolean` on:
  - `core.model.Tournament`
  - `api.action.TournamentReaction.Tournament` (returned in reactions)
- **Not** added to `TournamentAction.Add` — clients cannot set the flag via the action API. The flag is owned by the storage/server layer; this PR does not yet add an action to toggle it.
- The DTOs are non-nullable, so a `Tournament` value always carries an explicit lock state.

### 3. `Permissions.kt` — lock enforcement

Every mutation-permission helper that operates on something belonging to a tournament now requires a `Tournament` parameter and short-circuits to `false` when `tournament.isLocked`. The generic plural variants (`canRemoveTournaments`, `canAddGames`, `canRemoveGames`, `canEditGames`, `canAddTeams`, `canRemoveTeams`) were removed: they had no tournament context and were a hole in the lock guarantee. The admin role check they performed has been inlined into each tournament-aware variant.

| Helper | Status |
| --- | --- |
| `canAddTournaments()` | kept — creation has no existing tournament to lock against |
| `canRemoveTournament(tournament)` | new (replaces `canRemoveTournaments`) |
| `canAddGame(tournament, teams)` | now denies when locked |
| `canRemoveGame(tournament)` | new (replaces `canRemoveGames`) |
| `canEditGame(tournament)` | new (replaces `canEditGames`) |
| `canCreateTeamJoinInviteForGame(game, tournament)` | now takes tournament; denies when locked |
| `canCreateRefereeInviteForGame(game, tournament)` | now denies when locked |
| `canJoinGame(team, tournament)` | now takes tournament; denies when locked |
| `canAddTeam(tournament)` | now denies when locked |
| `canRemoveTeam(tournament)` | new (replaces `canRemoveTeams`) |
| `canEditTeam(teamId, tournament)` | now takes tournament; denies when locked |
| `canJudgeGame(game, tournament)` | now denies when locked (judging produces events, which mutate tournament data) |
| `canInviteMembers(team)` | **intentionally unchanged** — team members can still be added/managed after a tournament finishes and locks |
| `canRevokeMemberInvite(team)` | **intentionally unchanged** — same reason |

#### `canViewGame` regression fix

`canViewGame` previously short-circuited via `canJudgeGame`. Once `canJudgeGame` started returning `false` for locked tournaments, a referee of a game lost view access the moment the tournament locked. Fixed by having `canViewGame` short-circuit on the referee role directly (the other `canJudgeGame` cases — admin, stick-league captain — are already covered by the admin check above and the public-tournament fallback below; the latter relies on the assumption that current stick league tournaments are public).

## Notes / follow-ups

- **Breaking changes for downstream consumers** of this library: signatures of `canCreateTeamJoinInviteForGame`, `canJoinGame`, `canEditTeam`, and `canCreateRefereeInviteForGame` now require a `Tournament`; the six removed plural helpers will need to be replaced with their tournament-aware counterparts.
- A locked tournament cannot currently be removed by anyone, including super-admins. If a "lock-opener" path is needed later, the lock check in `canRemoveTournament` (and elsewhere) will need to be relaxed for that role.
- No action is exposed for setting `isLocked`. Adding one is a follow-up if/when needed.

## Test plan

- [ ] Build the library on JVM, JS, Native and WASM targets (could not be verified locally — Gradle dependencies are not cached and the sandbox has no network access).
- [ ] Verify `Tournament` and `TournamentReaction.Tournament` round-trip through `kotlinx.serialization` with `startDate`/`endDate` both present and absent.
- [ ] Spot-check downstream consumers for compilation breakage from the removed plural helpers and changed signatures.
- [ ] Behavioural check: with a locked tournament, every `canX(..., tournament)` mutation helper returns `false` for an admin; `canInviteMembers` / `canRevokeMemberInvite` still return `true` for a captain.
- [ ] `canViewGame` returns `true` for a referee of the game even when the tournament is locked.

https://claude.ai/code/session_01KDy2Q7PkMq8qKn9senrG3S