### PR TITLE
Refine game removal permissions

### DIFF
--- a/library/src/commonMain/kotlin/dk/spilpind/sms/core/Permissions.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/core/Permissions.kt
@@ -265,19 +265,13 @@ object Permissions {
     }
 
     fun User.Privileged.canJudgeGame(game: Game, tournament: Tournament): Boolean {
-        return if (tournament.isLocked) {
-            false
-        } else if (
-            hasSystemRole(UserRole.ContextRole.System.Admin)
-            || hasRole(UserRole.ContextRole.Game.Referee, contextId = game.gameId)
-        ) {
-            true
-        } else if (tournament.isCurrentStickLeague) {
-            val teamId = game.teamAId ?: return false // This is the team creating the game
-            hasRole(role = UserRole.ContextRole.Team.Captain, contextId = teamId)
-        } else {
-            false
+        if (tournament.isLocked) {
+            return false
         }
+
+        return hasSystemRole(UserRole.ContextRole.System.Admin)
+                || hasRole(UserRole.ContextRole.Game.Referee, contextId = game.gameId)
+                || isStickLeagueTeamACaptain(game = game, tournament = tournament)
     }
 
     /**

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/core/Permissions.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/core/Permissions.kt
@@ -148,14 +148,15 @@ object Permissions {
             return false
         }
 
-        val stateAllowsRemoval = when (game.state) {
-            Game.State.NOT_STARTED -> true
+        when (game.state) {
+            Game.State.NOT_STARTED -> {}
             Game.State.STARTED,
             Game.State.PAUSED,
-            Game.State.FINISHED -> false
+            Game.State.FINISHED -> return false
         }
 
-        return stateAllowsRemoval && hasSystemRole(UserRole.ContextRole.System.Admin)
+        return hasSystemRole(UserRole.ContextRole.System.Admin)
+                || isStickLeagueTeamACaptain(game = game, tournament = tournament)
     }
 
     /**
@@ -284,6 +285,19 @@ object Permissions {
      */
     fun User.Privileged.canIgnoreImportantPrompts(): Boolean {
         return hasSystemRole(UserRole.ContextRole.System.Admin)
+    }
+
+    /**
+     * Checks if the user is a captain of team A of the specified [game] in the specified [tournament] if that
+     * tournament is the current stick league. For a stick league, team A represents the team that created the game
+     */
+    private fun User.Privileged.isStickLeagueTeamACaptain(game: Game, tournament: Tournament): Boolean {
+        if (!tournament.isCurrentStickLeague) {
+            return false
+        }
+
+        val teamAId = game.teamAId ?: return false
+        return hasRole(role = UserRole.ContextRole.Team.Captain, contextId = teamAId)
     }
 
     private fun User.Privileged?.canViewStickLeagueGame(game: Game): Boolean {

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/core/Permissions.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/core/Permissions.kt
@@ -141,10 +141,28 @@ object Permissions {
     }
 
     /**
-     * Checks if the user can remove a game in the specified [tournament]
+     * Checks if the user can remove the specified [game] when associated with the specified [tournament]
      */
-    fun User.Privileged.canRemoveGame(tournament: Tournament): Boolean {
-        return !tournament.isLocked && hasSystemRole(UserRole.ContextRole.System.Admin)
+    fun User.Privileged.canRemoveGame(game: Game.Typed, tournament: Tournament): Boolean {
+        if (tournament.isLocked) {
+            return false
+        }
+
+        val stateAllowsRemoval = when (game.state) {
+            Game.State.NOT_STARTED -> true
+            Game.State.STARTED,
+            Game.State.PAUSED,
+            Game.State.FINISHED -> false
+        }
+
+        return stateAllowsRemoval && hasSystemRole(UserRole.ContextRole.System.Admin)
+    }
+
+    /**
+     * Checks if the user can remove the specified [game]
+     */
+    fun User.Privileged.canRemoveGame(game: Game.Detailed): Boolean {
+        return canRemoveGame(game = game, tournament = game.tournament)
     }
 
     /**

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/Game.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/Game.kt
@@ -43,6 +43,16 @@ sealed interface Game {
     }
 
     /**
+     * A [Game] that exposes its state as a typed [State] value rather than only the raw [gameState] string
+     */
+    sealed interface Typed : Game {
+        val state: State
+
+        override val gameState: String
+            get() = state.identifier
+    }
+
+    /**
      * Represents the raw game
      */
     data class Raw(
@@ -66,15 +76,13 @@ sealed interface Game {
         override val tournamentId: Tournament.Id,
         override val teamAId: Team.Id?,
         override val teamBId: Team.Id?,
-        val state: State,
+        override val state: State,
         override val teamAPoints: Int,
         override val teamBPoints: Int,
         override val description: String,
         override val teamJoinInviteCode: String?,
         override val refereeInviteCode: String?
-    ) : Game {
-        override val gameState: String = state.identifier
-    }
+    ) : Typed
 
     /**
      * Like [Simple] with actual representations of tournament and the teams
@@ -84,16 +92,15 @@ sealed interface Game {
         val tournament: Tournament,
         val teamA: Team?,
         val teamB: Team?,
-        val state: State,
+        override val state: State,
         override val teamAPoints: Int,
         override val teamBPoints: Int,
         override val description: String,
         override val teamJoinInviteCode: String?,
         override val refereeInviteCode: String?
-    ) : Game {
+    ) : Typed {
         override val tournamentId = tournament.tournamentId
         override val teamAId = teamA?.teamId
         override val teamBId = teamB?.teamId
-        override val gameState: String = state.identifier
     }
 }


### PR DESCRIPTION
Restricts `canRemoveGame` so a game can only be removed while it hasn't started, and lets the captain of team A remove their own game in stick league. Adds a `Game.Typed` sub-interface to support the typed state check and a shared `isStickLeagueTeamACaptain` helper that's also reused in `canJudgeGame`.