### PR TITLE
Add GameRules model and API support for managing game rule sets

### DIFF
--- a/library/src/commonMain/kotlin/dk/spilpind/sms/api/RequestSerializerInterceptor.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/api/RequestSerializerInterceptor.kt
@@ -103,6 +103,18 @@ object RequestSerializerInterceptor : JsonTransformingSerializer<Request>(Reques
                     Action.RevokeRequest -> null
                     Action.AcceptRequest -> GameAction.AcceptRequest.serializer()
                 }
+                Context.GameRules -> when (action) {
+                    Action.Inform -> null
+                    Action.Add -> GameRulesAction.Add.serializer()
+                    Action.Remove -> null
+                    Action.Update -> null
+                    Action.Accept -> null
+                    Action.Subscribe -> GameRulesAction.Subscribe.serializer()
+                    Action.Unsubscribe -> null
+                    Action.CreateRequest -> null
+                    Action.RevokeRequest -> null
+                    Action.AcceptRequest -> null
+                }
                 Context.Team -> when (action) {
                     Action.Inform -> null
                     Action.Add -> TeamAction.Add.serializer()

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/api/RequestSerializerInterceptor.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/api/RequestSerializerInterceptor.kt
@@ -110,7 +110,7 @@ object RequestSerializerInterceptor : JsonTransformingSerializer<Request>(Reques
                     Action.Update -> null
                     Action.Accept -> null
                     Action.Subscribe -> GameRulesAction.Subscribe.serializer()
-                    Action.Unsubscribe -> null
+                    Action.Unsubscribe -> GameRulesAction.Unsubscribe.serializer()
                     Action.CreateRequest -> null
                     Action.RevokeRequest -> null
                     Action.AcceptRequest -> null

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/api/ResponseSerializerInterceptor.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/api/ResponseSerializerInterceptor.kt
@@ -71,6 +71,7 @@ object ResponseSerializerInterceptor : JsonTransformingSerializer<Response>(Resp
                     Context.UserRole -> null
                     Context.Tournament -> null
                     Context.Game -> null
+                    Context.GameRules -> null
                     Context.Team -> null
                     Context.Referee -> null
                 }
@@ -83,6 +84,7 @@ object ResponseSerializerInterceptor : JsonTransformingSerializer<Response>(Resp
                     Context.UserRole -> UserRoleReaction.Added.serializer()
                     Context.Tournament -> TournamentReaction.Added.serializer()
                     Context.Game -> GameReaction.Added.serializer()
+                    Context.GameRules -> GameRulesReaction.Added.serializer()
                     Context.Team -> TeamReaction.Added.serializer()
                     Context.Referee -> null
                 }
@@ -95,6 +97,7 @@ object ResponseSerializerInterceptor : JsonTransformingSerializer<Response>(Resp
                     Context.UserRole -> null
                     Context.Tournament -> TournamentReaction.Removed.serializer()
                     Context.Game -> GameReaction.Removed.serializer()
+                    Context.GameRules -> null
                     Context.Team -> TeamReaction.Removed.serializer()
                     Context.Referee -> null
                 }
@@ -107,6 +110,7 @@ object ResponseSerializerInterceptor : JsonTransformingSerializer<Response>(Resp
                     Context.UserRole -> UserRoleReaction.Updated.serializer()
                     Context.Tournament -> TournamentReaction.Updated.serializer()
                     Context.Game -> GameReaction.Updated.serializer()
+                    Context.GameRules -> GameRulesReaction.Updated.serializer()
                     Context.Team -> TeamReaction.Updated.serializer()
                     Context.Referee -> RefereeReaction.Updated.serializer()
                 }
@@ -119,6 +123,7 @@ object ResponseSerializerInterceptor : JsonTransformingSerializer<Response>(Resp
                     Context.UserRole -> null
                     Context.Tournament -> null
                     Context.Game -> GameReaction.Accepted.serializer()
+                    Context.GameRules -> null
                     Context.Team -> null
                     Context.Referee -> null
                 }
@@ -131,6 +136,7 @@ object ResponseSerializerInterceptor : JsonTransformingSerializer<Response>(Resp
                     Context.UserRole -> UserRoleReaction.Subscribed.serializer()
                     Context.Tournament -> TournamentReaction.Subscribed.serializer()
                     Context.Game -> GameReaction.Subscribed.serializer()
+                    Context.GameRules -> GameRulesReaction.Subscribed.serializer()
                     Context.Team -> TeamReaction.Subscribed.serializer()
                     Context.Referee -> RefereeReaction.Subscribed.serializer()
                 }
@@ -143,6 +149,7 @@ object ResponseSerializerInterceptor : JsonTransformingSerializer<Response>(Resp
                     Context.UserRole -> UserRoleReaction.Unsubscribed.serializer()
                     Context.Tournament -> TournamentReaction.Unsubscribed.serializer()
                     Context.Game -> GameReaction.Unsubscribed.serializer()
+                    Context.GameRules -> null
                     Context.Team -> TeamReaction.Unsubscribed.serializer()
                     Context.Referee -> RefereeReaction.Unsubscribed.serializer()
                 }
@@ -155,6 +162,7 @@ object ResponseSerializerInterceptor : JsonTransformingSerializer<Response>(Resp
                     Context.UserRole -> null
                     Context.Tournament -> null
                     Context.Game -> GameReaction.RequestCreated.serializer()
+                    Context.GameRules -> null
                     Context.Team -> TeamReaction.RequestCreated.serializer()
                     Context.Referee -> null
                 }
@@ -167,6 +175,7 @@ object ResponseSerializerInterceptor : JsonTransformingSerializer<Response>(Resp
                     Context.UserRole -> null
                     Context.Tournament -> null
                     Context.Game -> null
+                    Context.GameRules -> null
                     Context.Team -> TeamReaction.RequestRevoked.serializer()
                     Context.Referee -> null
                 }
@@ -179,6 +188,7 @@ object ResponseSerializerInterceptor : JsonTransformingSerializer<Response>(Resp
                     Context.UserRole -> null
                     Context.Tournament -> null
                     Context.Game -> GameReaction.RequestAccepted.serializer()
+                    Context.GameRules -> null
                     Context.Team -> TeamReaction.RequestAccepted.serializer()
                     Context.Referee -> null
                 }

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/api/ResponseSerializerInterceptor.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/api/ResponseSerializerInterceptor.kt
@@ -149,7 +149,7 @@ object ResponseSerializerInterceptor : JsonTransformingSerializer<Response>(Resp
                     Context.UserRole -> UserRoleReaction.Unsubscribed.serializer()
                     Context.Tournament -> TournamentReaction.Unsubscribed.serializer()
                     Context.Game -> GameReaction.Unsubscribed.serializer()
-                    Context.GameRules -> null
+                    Context.GameRules -> GameRulesReaction.Unsubscribed.serializer()
                     Context.Team -> TeamReaction.Unsubscribed.serializer()
                     Context.Referee -> RefereeReaction.Unsubscribed.serializer()
                 }

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/api/action/GameAction.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/api/action/GameAction.kt
@@ -21,8 +21,8 @@ sealed class GameAction : ContextAction() {
         val tournamentId: Int,
         val teamAId: Int?,
         val teamBId: Int?,
-        val gameRulesId: Int?,
         val description: String,
+        val gameRulesId: Int?,
         val addTeamJoinInvite: Boolean = false
     ) : GameAction() {
         override val action: Action = Action.Add

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/api/action/GameAction.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/api/action/GameAction.kt
@@ -21,6 +21,7 @@ sealed class GameAction : ContextAction() {
         val tournamentId: Int,
         val teamAId: Int?,
         val teamBId: Int?,
+        val gameRulesId: Int?,
         val description: String,
         val addTeamJoinInvite: Boolean = false
     ) : GameAction() {

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/api/action/GameReaction.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/api/action/GameReaction.kt
@@ -91,11 +91,11 @@ sealed class GameReaction : ContextReaction() {
         val tournamentId: Int,
         val teamAId: Int?,
         val teamBId: Int?,
-        val gameRulesId: Int?,
         val gameState: String,
         val teamAPoints: Int,
         val teamBPoints: Int,
         val description: String,
+        val gameRulesId: Int?,
         val teamJoinInviteCode: String? = null,
         val refereeInviteCode: String? = null
     )

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/api/action/GameReaction.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/api/action/GameReaction.kt
@@ -91,6 +91,7 @@ sealed class GameReaction : ContextReaction() {
         val tournamentId: Int,
         val teamAId: Int?,
         val teamBId: Int?,
+        val gameRulesId: Int?,
         val gameState: String,
         val teamAPoints: Int,
         val teamBPoints: Int,

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/api/action/GameRulesAction.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/api/action/GameRulesAction.kt
@@ -29,11 +29,20 @@ sealed class GameRulesAction : ContextAction() {
 
     /**
      * Subscribes to changes for the game rules identified by [gameRulesId]. The subscription will be kept alive until
-     * the session is destroyed. Changes will be sent via relevant [GameRulesReaction]s. A successful response to this
-     * would be [GameRulesReaction.Subscribed] followed by [GameRulesReaction.Updated]
+     * the session is destroyed or [Unsubscribe] is called. Changes will be sent via relevant [GameRulesReaction]s. A
+     * successful response to this would be [GameRulesReaction.Subscribed] followed by [GameRulesReaction.Updated]
      */
     @Serializable
     data class Subscribe(val gameRulesId: Int) : GameRulesAction() {
         override val action: Action = Action.Subscribe
+    }
+
+    /**
+     * Unsubscribes the socket from updates to the game rules identified by [gameRulesId], previously subscribed by
+     * [Subscribe]. A successful response to this would be [GameRulesReaction.Unsubscribed]
+     */
+    @Serializable
+    data class Unsubscribe(val gameRulesId: Int) : GameRulesAction() {
+        override val action: Action = Action.Unsubscribe
     }
 }

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/api/action/GameRulesAction.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/api/action/GameRulesAction.kt
@@ -1,0 +1,39 @@
+package dk.spilpind.sms.api.action
+
+import dk.spilpind.sms.api.common.Action
+import dk.spilpind.sms.core.model.Context
+import kotlinx.serialization.Serializable
+import kotlin.time.Duration
+
+/**
+ * All possible actions that can be made in relation to [Context.GameRules]
+ */
+@Serializable
+sealed class GameRulesAction : ContextAction() {
+    override val context: Context = Context.GameRules
+
+    /**
+     * Adds a new set of game rules. The created entry is not attached to any game or tournament - that is handled
+     * separately. Null values represent disabled restrictions, not placeholders for the system defaults. A successful
+     * response to this would be [GameRulesReaction.Added]
+     */
+    @Serializable
+    data class Add(
+        val gameTimeThreshold: Duration?,
+        val gamePointThreshold: Int?,
+        val turnTimeThreshold: Duration?,
+        val turnDeathThreshold: Int,
+    ) : GameRulesAction() {
+        override val action: Action = Action.Add
+    }
+
+    /**
+     * Subscribes to changes for the game rules identified by [gameRulesId]. The subscription will be kept alive until
+     * the session is destroyed. Changes will be sent via relevant [GameRulesReaction]s. A successful response to this
+     * would be [GameRulesReaction.Subscribed] followed by [GameRulesReaction.Updated]
+     */
+    @Serializable
+    data class Subscribe(val gameRulesId: Int) : GameRulesAction() {
+        override val action: Action = Action.Subscribe
+    }
+}

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/api/action/GameRulesReaction.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/api/action/GameRulesReaction.kt
@@ -29,6 +29,14 @@ sealed class GameRulesReaction : ContextReaction() {
     }
 
     /**
+     * Response to [GameRulesAction.Unsubscribe]
+     */
+    @Serializable
+    class Unsubscribed : GameRulesReaction() {
+        override val reaction: Reaction = Reaction.Unsubscribed
+    }
+
+    /**
      * Response to a change in the subscribed game rules. Carries the current state of the entry
      */
     @Serializable

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/api/action/GameRulesReaction.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/api/action/GameRulesReaction.kt
@@ -1,0 +1,50 @@
+package dk.spilpind.sms.api.action
+
+import dk.spilpind.sms.api.common.Reaction
+import dk.spilpind.sms.core.model.Context
+import kotlinx.serialization.Serializable
+import kotlin.time.Duration
+
+/**
+ * All possible reactions that can be made in relation to [Context.GameRules]
+ */
+@Serializable
+sealed class GameRulesReaction : ContextReaction() {
+    override val context: Context = Context.GameRules
+
+    /**
+     * Response to [GameRulesAction.Add]
+     */
+    @Serializable
+    data class Added(val gameRules: GameRules) : GameRulesReaction() {
+        override val reaction: Reaction = Reaction.Added
+    }
+
+    /**
+     * Response to [GameRulesAction.Subscribe]
+     */
+    @Serializable
+    class Subscribed : GameRulesReaction() {
+        override val reaction: Reaction = Reaction.Subscribed
+    }
+
+    /**
+     * Response to a change in the subscribed game rules. Carries the current state of the entry
+     */
+    @Serializable
+    data class Updated(val gameRules: GameRules) : GameRulesReaction() {
+        override val reaction: Reaction = Reaction.Updated
+    }
+
+    /**
+     * Represents a single set of game rules
+     */
+    @Serializable
+    data class GameRules(
+        val gameRulesId: Int,
+        val gameTimeThreshold: Duration?,
+        val gamePointThreshold: Int?,
+        val turnTimeThreshold: Duration?,
+        val turnDeathThreshold: Int,
+    )
+}

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/api/action/TournamentAction.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/api/action/TournamentAction.kt
@@ -19,7 +19,8 @@ sealed class TournamentAction : ContextAction() {
     data class Add(
         val name: String,
         val startDate: LocalDate? = null,
-        val endDate: LocalDate? = null
+        val endDate: LocalDate? = null,
+        val gameRulesId: Int?
     ) : TournamentAction() {
         override val action: Action = Action.Add
     }

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/api/action/TournamentReaction.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/api/action/TournamentReaction.kt
@@ -67,6 +67,7 @@ sealed class TournamentReaction : ContextReaction() {
         val isLocked: Boolean,
         val tags: List<String>,
         val startDate: LocalDate?,
-        val endDate: LocalDate?
+        val endDate: LocalDate?,
+        val gameRulesId: Int?
     )
 }

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/Context.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/Context.kt
@@ -17,6 +17,7 @@ enum class Context(val contextKey: String) {
     UserRole("userRole"),
     Tournament("tournament"),
     Game("game"),
+    GameRules("gameRules"),
     Team("team"),
     Referee("referee"),
 }

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/Game.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/Game.kt
@@ -15,6 +15,11 @@ sealed interface Game {
     val teamAPoints: Int
     val teamBPoints: Int
     val description: String
+
+    /**
+     * Game rules attached directly to this game. When null, special rules might still apply via the tournament or, as a
+     * last resort, via [GameConstants]
+     */
     val gameRulesId: GameRules.Id?
     val teamJoinInviteCode: String?
     val refereeInviteCode: String?

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/Game.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/Game.kt
@@ -11,6 +11,7 @@ sealed interface Game {
     val tournamentId: Tournament.Id
     val teamAId: Team.Id?
     val teamBId: Team.Id?
+    val gameRulesId: GameRules.Id?
     val gameState: String
     val teamAPoints: Int
     val teamBPoints: Int
@@ -60,6 +61,7 @@ sealed interface Game {
         override val tournamentId: Tournament.Id,
         override val teamAId: Team.Id?,
         override val teamBId: Team.Id?,
+        override val gameRulesId: GameRules.Id?,
         override val gameState: String,
         override val teamAPoints: Int,
         override val teamBPoints: Int,
@@ -76,6 +78,7 @@ sealed interface Game {
         override val tournamentId: Tournament.Id,
         override val teamAId: Team.Id?,
         override val teamBId: Team.Id?,
+        override val gameRulesId: GameRules.Id?,
         override val state: State,
         override val teamAPoints: Int,
         override val teamBPoints: Int,
@@ -85,13 +88,14 @@ sealed interface Game {
     ) : Typed
 
     /**
-     * Like [Simple] with actual representations of tournament and the teams
+     * Like [Simple] with actual representations of tournament, the teams and the optionally attached rules
      */
     data class Detailed(
         override val gameId: Id,
         val tournament: Tournament,
         val teamA: Team?,
         val teamB: Team?,
+        val rules: GameRules?,
         override val state: State,
         override val teamAPoints: Int,
         override val teamBPoints: Int,
@@ -102,5 +106,6 @@ sealed interface Game {
         override val tournamentId = tournament.tournamentId
         override val teamAId = teamA?.teamId
         override val teamBId = teamB?.teamId
+        override val gameRulesId = rules?.gameRulesId
     }
 }

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/Game.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/Game.kt
@@ -11,11 +11,11 @@ sealed interface Game {
     val tournamentId: Tournament.Id
     val teamAId: Team.Id?
     val teamBId: Team.Id?
-    val gameRulesId: GameRules.Id?
     val gameState: String
     val teamAPoints: Int
     val teamBPoints: Int
     val description: String
+    val gameRulesId: GameRules.Id?
     val teamJoinInviteCode: String?
     val refereeInviteCode: String?
 
@@ -61,11 +61,11 @@ sealed interface Game {
         override val tournamentId: Tournament.Id,
         override val teamAId: Team.Id?,
         override val teamBId: Team.Id?,
-        override val gameRulesId: GameRules.Id?,
         override val gameState: String,
         override val teamAPoints: Int,
         override val teamBPoints: Int,
         override val description: String,
+        override val gameRulesId: GameRules.Id?,
         override val teamJoinInviteCode: String?,
         override val refereeInviteCode: String?
     ) : Game
@@ -78,11 +78,11 @@ sealed interface Game {
         override val tournamentId: Tournament.Id,
         override val teamAId: Team.Id?,
         override val teamBId: Team.Id?,
-        override val gameRulesId: GameRules.Id?,
         override val state: State,
         override val teamAPoints: Int,
         override val teamBPoints: Int,
         override val description: String,
+        override val gameRulesId: GameRules.Id?,
         override val teamJoinInviteCode: String?,
         override val refereeInviteCode: String?
     ) : Typed
@@ -95,11 +95,11 @@ sealed interface Game {
         val tournament: Tournament,
         val teamA: Team?,
         val teamB: Team?,
-        val rules: GameRules?,
         override val state: State,
         override val teamAPoints: Int,
         override val teamBPoints: Int,
         override val description: String,
+        val rules: GameRules?,
         override val teamJoinInviteCode: String?,
         override val refereeInviteCode: String?
     ) : Typed {

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/GameConstants.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/GameConstants.kt
@@ -4,9 +4,10 @@ import kotlin.time.Duration
 import kotlin.time.Duration.Companion.minutes
 
 /**
- * System defaults applied to games that don't have a [GameRules] attached - either directly or via their tournament.
- * Each threshold here mirrors a field on [GameRules]; a null value means the corresponding restriction is disabled by
- * default
+ * Game defaults applied to games that don't have a [GameRules] attached - either directly or via their tournament.
+ * Each threshold here mirrors a field on [GameRules] (a null value means the corresponding restriction is disabled by
+ * default), except for [DEFAULT_FAULT_THRESHOLD], which isn't configurable per game and so has no [GameRules]
+ * counterpart
  */
 object GameConstants {
     val DEFAULT_GAME_TIME_THRESHOLD: Duration? = 20.minutes

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/GameConstants.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/GameConstants.kt
@@ -1,0 +1,17 @@
+package dk.spilpind.sms.core.model
+
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
+
+/**
+ * System defaults applied to games that don't have a [GameRules] attached - either directly or via their tournament.
+ * Each threshold here mirrors a field on [GameRules]; a null value means the corresponding restriction is disabled by
+ * default
+ */
+object GameConstants {
+    val DEFAULT_GAME_TIME_THRESHOLD: Duration? = 20.minutes
+    val DEFAULT_GAME_POINT_THRESHOLD: Int? = null
+    val DEFAULT_TURN_TIME_THRESHOLD: Duration? = 5.minutes
+    val DEFAULT_TURN_DEATH_THRESHOLD: Int = 2
+    val DEFAULT_FAULT_THRESHOLD: Int = 3
+}

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/GameRules.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/GameRules.kt
@@ -1,0 +1,29 @@
+package dk.spilpind.sms.core.model
+
+import kotlin.jvm.JvmInline
+import kotlin.time.Duration
+
+/**
+ * Represents a set of game rules that overrides the system defaults (see [GameConstants]) when attached to a game or
+ * tournament. Nulls indicate that the corresponding restriction is disabled - they are not placeholders that should be
+ * resolved from the defaults
+ */
+data class GameRules(
+    val gameRulesId: Id,
+    val gameTimeThreshold: Duration?,
+    val gamePointThreshold: Int?,
+    val turnTimeThreshold: Duration?,
+    val turnDeathThreshold: Int,
+) {
+
+    /**
+     * Id of a game rules entry. Can be used to reference a rules entry without having to care about the remaining data
+     */
+    @JvmInline
+    value class Id(override val identifier: Int) : ContextIdentifier, Comparable<Id> {
+
+        override fun compareTo(other: Id): Int =
+            identifier.compareTo(other.identifier)
+
+    }
+}

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/GameRules.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/GameRules.kt
@@ -4,7 +4,7 @@ import kotlin.jvm.JvmInline
 import kotlin.time.Duration
 
 /**
- * Represents a set of game rules that overrides the system defaults (see [GameConstants]) when attached to a game or
+ * Represents a set of game rules that overrides the defaults (see [GameConstants]) when attached to a game or
  * tournament. Nulls indicate that the corresponding restriction is disabled - they are not placeholders that should be
  * resolved from the defaults
  */

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/ModelHelper.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/ModelHelper.kt
@@ -78,6 +78,7 @@ object ModelHelper {
         tournamentId = tournamentId,
         teamAId = teamAId,
         teamBId = teamBId,
+        gameRulesId = gameRulesId,
         state = Game.State.entries.firstOrNull { state -> state.identifier == gameState }
             ?: throw IllegalStateException("Got unknown game state: $gameState"),
         teamAPoints = teamAPoints,
@@ -91,11 +92,17 @@ object ModelHelper {
      * Converts a simple game to a detailed game. It is expected that the provided parameters matches the properties of
      * the simple game
      */
-    fun Game.Simple.toDetailedGame(tournament: Tournament, teamA: Team?, teamB: Team?) = Game.Detailed(
+    fun Game.Simple.toDetailedGame(
+        tournament: Tournament,
+        teamA: Team?,
+        teamB: Team?,
+        rules: GameRules?,
+    ) = Game.Detailed(
         gameId = gameId,
         tournament = tournament,
         teamA = teamA,
         teamB = teamB,
+        rules = rules,
         state = state,
         teamAPoints = teamAPoints,
         teamBPoints = teamBPoints,
@@ -112,6 +119,7 @@ object ModelHelper {
         tournamentId = tournamentId,
         teamAId = teamAId,
         teamBId = teamBId,
+        gameRulesId = gameRulesId,
         state = state,
         teamAPoints = teamAPoints,
         teamBPoints = teamBPoints,
@@ -144,6 +152,11 @@ object ModelHelper {
      * Creates a tournament id from the integer
      */
     fun Int.toTournamentId() = Tournament.Id(this)
+
+    /**
+     * Creates a game rules id from the integer
+     */
+    fun Int.toGameRulesId() = GameRules.Id(this)
 
     /**
      * Creates a user id from the integer

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/ModelHelper.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/ModelHelper.kt
@@ -78,12 +78,12 @@ object ModelHelper {
         tournamentId = tournamentId,
         teamAId = teamAId,
         teamBId = teamBId,
-        gameRulesId = gameRulesId,
         state = Game.State.entries.firstOrNull { state -> state.identifier == gameState }
             ?: throw IllegalStateException("Got unknown game state: $gameState"),
         teamAPoints = teamAPoints,
         teamBPoints = teamBPoints,
         description = description,
+        gameRulesId = gameRulesId,
         teamJoinInviteCode = teamJoinInviteCode,
         refereeInviteCode = refereeInviteCode
     )
@@ -102,11 +102,11 @@ object ModelHelper {
         tournament = tournament,
         teamA = teamA,
         teamB = teamB,
-        rules = rules,
         state = state,
         teamAPoints = teamAPoints,
         teamBPoints = teamBPoints,
         description = description,
+        rules = rules,
         teamJoinInviteCode = teamJoinInviteCode,
         refereeInviteCode = refereeInviteCode
     )
@@ -119,11 +119,11 @@ object ModelHelper {
         tournamentId = tournamentId,
         teamAId = teamAId,
         teamBId = teamBId,
-        gameRulesId = gameRulesId,
         state = state,
         teamAPoints = teamAPoints,
         teamBPoints = teamBPoints,
         description = description,
+        gameRulesId = gameRulesId,
         teamJoinInviteCode = teamJoinInviteCode,
         refereeInviteCode = refereeInviteCode
     )

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/Tournament.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/Tournament.kt
@@ -6,15 +6,15 @@ import kotlin.jvm.JvmInline
 /**
  * Represents data about a tournament
  */
-data class Tournament(
-    val tournamentId: Id,
-    val name: String,
-    val isPublic: Boolean,
-    val isLocked: Boolean,
-    val tags: List<String>,
-    val startDate: LocalDate?,
+sealed interface Tournament {
+    val tournamentId: Id
+    val name: String
+    val isPublic: Boolean
+    val isLocked: Boolean
+    val tags: List<String>
+    val startDate: LocalDate?
     val endDate: LocalDate?
-) {
+    val gameRulesId: GameRules.Id?
 
     /**
      * Id of a tournament. Can be used to reference a tournament without having to care about the tournament game data
@@ -25,5 +25,35 @@ data class Tournament(
         override fun compareTo(other: Id): Int =
             identifier.compareTo(other.identifier)
 
+    }
+
+    /**
+     * Represents the raw tournament
+     */
+    data class Raw(
+        override val tournamentId: Id,
+        override val name: String,
+        override val isPublic: Boolean,
+        override val isLocked: Boolean,
+        override val tags: List<String>,
+        override val startDate: LocalDate?,
+        override val endDate: LocalDate?,
+        override val gameRulesId: GameRules.Id?,
+    ) : Tournament
+
+    /**
+     * Like [Raw] with the embedded [rules] referenced by the tournament (if any)
+     */
+    data class Detailed(
+        override val tournamentId: Id,
+        override val name: String,
+        override val isPublic: Boolean,
+        override val isLocked: Boolean,
+        override val tags: List<String>,
+        override val startDate: LocalDate?,
+        override val endDate: LocalDate?,
+        val rules: GameRules?,
+    ) : Tournament {
+        override val gameRulesId = rules?.gameRulesId
     }
 }

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/Tournament.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/Tournament.kt
@@ -14,6 +14,11 @@ sealed interface Tournament {
     val tags: List<String>
     val startDate: LocalDate?
     val endDate: LocalDate?
+
+    /**
+     * Game rules applied to every game in the tournament that doesn't itself specify a [Game.gameRulesId]. When null,
+     * [GameConstants] is used as a last resort
+     */
     val gameRulesId: GameRules.Id?
 
     /**


### PR DESCRIPTION
## Summary
This PR introduces a new `GameRules` domain model and corresponding API actions/reactions to support managing customizable game rule sets that can be attached to tournaments and games. This allows overriding system defaults (defined in `GameConstants`) on a per-tournament or per-game basis.

## Key Changes

- **New Core Models**
  - `GameRules`: Represents a set of game rules with configurable thresholds (game time, game points, turn time, turn death)
  - `GameConstants`: Defines system-wide default values for game restrictions
  - `GameRules.Id`: Inline value class for type-safe rule set identification

- **API Layer**
  - `GameRulesAction`: New sealed class with `Add` and `Subscribe` actions for creating and monitoring rule sets
  - `GameRulesReaction`: New sealed class with `Added`, `Subscribed`, and `Updated` reactions
  - Updated serializer interceptors (`RequestSerializerInterceptor`, `ResponseSerializerInterceptor`) to handle GameRules context

- **Model Updates**
  - `Tournament`: Converted from data class to sealed interface with `Raw` and `Detailed` variants
    - Added `gameRulesId` field to reference attached rules
    - `Detailed` variant includes embedded `GameRules` object
  - `Game`: Added `gameRulesId` field to both `Simple` and `Typed` variants
    - `Detailed` variant now includes optional `rules` field
  - `Context` enum: Added `GameRules` context type

- **API Contract Updates**
  - `TournamentAction.Add`: Added optional `gameRulesId` parameter
  - `TournamentReaction`: Updated tournament data class with `gameRulesId` field
  - `GameAction.Add`: Added optional `gameRulesId` parameter
  - `GameReaction`: Updated game data classes with `gameRulesId` field

- **Helper Methods**
  - `ModelHelper.toGameRulesId()`: Extension function for converting Int to GameRules.Id
  - `ModelHelper.toDetailedGame()`: Updated to accept and map rules parameter

## Implementation Details

- Null values in `GameRules` thresholds represent disabled restrictions, not system default placeholders
- The `Detailed` tournament variant derives `gameRulesId` from the embedded rules object
- Game rules can be created independently and then attached to tournaments/games via their respective IDs
- Subscription support allows clients to monitor changes to specific rule sets in real-time

https://claude.ai/code/session_01GeyZNfGNv9QNLruXPScYPu