### PR TITLE
Default gameRulesId to null on Add actions

### DIFF
--- a/library/src/commonMain/kotlin/dk/spilpind/sms/api/action/GameAction.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/api/action/GameAction.kt
@@ -22,7 +22,7 @@ sealed class GameAction : ContextAction() {
         val teamAId: Int?,
         val teamBId: Int?,
         val description: String,
-        val gameRulesId: Int?,
+        val gameRulesId: Int? = null,
         val addTeamJoinInvite: Boolean = false
     ) : GameAction() {
         override val action: Action = Action.Add

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/api/action/TournamentAction.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/api/action/TournamentAction.kt
@@ -20,7 +20,7 @@ sealed class TournamentAction : ContextAction() {
         val name: String,
         val startDate: LocalDate? = null,
         val endDate: LocalDate? = null,
-        val gameRulesId: Int?
+        val gameRulesId: Int? = null
     ) : TournamentAction() {
         override val action: Action = Action.Add
     }


### PR DESCRIPTION
Lets older clients send GameAction.Add and TournamentAction.Add without the new field. Without the default, the field is required on the wire and clients that haven't been recompiled against the new sms-core would fail to deserialize on the server.

https://claude.ai/code/session_01GeyZNfGNv9QNLruXPScYPu