### PR TITLE
Tournament action: accept isPublic/tags on Add and add Update

### DIFF
--- a/library/src/commonMain/kotlin/dk/spilpind/sms/api/RequestSerializerInterceptor.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/api/RequestSerializerInterceptor.kt
@@ -83,7 +83,7 @@ object RequestSerializerInterceptor : JsonTransformingSerializer<Request>(Reques
                     Action.Inform -> null
                     Action.Add -> TournamentAction.Add.serializer()
                     Action.Remove -> TournamentAction.Remove.serializer()
-                    Action.Update -> null
+                    Action.Update -> TournamentAction.Update.serializer()
                     Action.Accept -> null
                     Action.Subscribe -> TournamentAction.Subscribe.serializer()
                     Action.Unsubscribe -> TournamentAction.Unsubscribe.serializer()

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/api/action/TournamentAction.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/api/action/TournamentAction.kt
@@ -37,6 +37,24 @@ sealed class TournamentAction : ContextAction() {
     }
 
     /**
+     * Updates the tournament with id [tournamentId] with the values provided. It is important to consider all values
+     * even though you're not allowed to change them, as for instance a value set to empty or null will be updated to
+     * that value
+     */
+    @Serializable
+    data class Update(
+        val tournamentId: Int,
+        val name: String,
+        val isPublic: Boolean,
+        val tags: List<String>,
+        val startDate: LocalDate?,
+        val endDate: LocalDate?,
+        val gameRulesId: Int?,
+    ) : TournamentAction() {
+        override val action: Action = Action.Update
+    }
+
+    /**
      * Subscribes to all tournaments available for the current user. The subscription will be kept alive until the
      * session is destroyed or [Unsubscribe] is called. Changes to the list will be sent via relevant
      * [TournamentReaction]s. A successful response to this would be [TournamentReaction.Subscribed] followed by

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/api/action/TournamentAction.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/api/action/TournamentAction.kt
@@ -18,6 +18,8 @@ sealed class TournamentAction : ContextAction() {
     @Serializable
     data class Add(
         val name: String,
+        val isPublic: Boolean = false,
+        val tags: List<String> = emptyList(),
         val startDate: LocalDate? = null,
         val endDate: LocalDate? = null,
         val gameRulesId: Int? = null

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/core/Permissions.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/core/Permissions.kt
@@ -97,6 +97,13 @@ object Permissions {
     }
 
     /**
+     * Checks if the user can edit the specified [tournament]
+     */
+    fun User.Privileged.canEditTournament(tournament: Tournament): Boolean {
+        return !tournament.isLocked && hasSystemRole(UserRole.ContextRole.System.Admin)
+    }
+
+    /**
      * Checks if the user (or "everyone" if null) can view the specified [game] when associated with the specified
      * [tournament]
      */


### PR DESCRIPTION
Two changes to `TournamentAction`:

- **Add**: now accepts `isPublic` and `tags`. Both have defaults (`false` / `emptyList()`) so existing clients keep working.
- **Update**: new action mirroring `GameAction.Update` / `TeamAction.Update`. Carries `tournamentId` plus all client-settable fields, no defaults. Wired up in `RequestSerializerInterceptor` and gated by a new `canEditTournament` permission that blocks edits when the tournament is locked.

`isLocked` stays server-only in both actions.