### PR TITLE
Allow updating game rules + move GameConstants out of model

### DIFF
--- a/library/src/commonMain/kotlin/dk/spilpind/sms/api/action/GameAction.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/api/action/GameAction.kt
@@ -47,6 +47,7 @@ sealed class GameAction : ContextAction() {
         val teamAId: Int?,
         val teamBId: Int?,
         val description: String,
+        val gameRulesId: Int?,
     ) : GameAction() {
         override val action: Action = Action.Update
     }

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/core/GameConstants.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/core/GameConstants.kt
@@ -1,4 +1,4 @@
-package dk.spilpind.sms.core.model
+package dk.spilpind.sms.core
 
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.minutes


### PR DESCRIPTION
## Summary

Two small, independent improvements — each in its own commit.

- **Accept `gameRulesId` on `GameAction.Update`** — `TournamentAction.Update` already accepts `gameRulesId`; the matching field was missing on `GameAction.Update`, so callers couldn't change the rules attached to an individual game once added. Adds `gameRulesId: Int?` to the data class, mirroring the tournament shape. The kdoc above `Update` already warns that every field is applied (including `null`), so `null` correctly clears the rules.
- **Move `GameConstants` out of the `model` package** — `GameConstants` is a constants object, not a model. Sibling utility singletons (`GameHelper`, `Permissions`, `TimeHelper`) already live in `dk.spilpind.sms.core`; this moves `GameConstants` there too. The three other references to it (`GameRules.kt`, `Game.kt`, `Tournament.kt`) are kdoc-only `[GameConstants]` links that resolve cross-package without imports, so no other files needed edits.

## Test plan

- [ ] `./gradlew build` passes locally (the sandboxed environment only had JDK 21, but the project's toolchain is pinned to JDK 17, so the build could not be verified here)
- [ ] Spot-check the `GameAction.kt` diff: only the `Update` data class changed
- [ ] Spot-check the `GameConstants.kt` move: file path changed and the `package` line is now `dk.spilpind.sms.core`

---
_Generated by [Claude Code](https://claude.ai/code/session_01FcbZ7YP2gyuUHMhTeAViXB)_