### PR TITLE
Add Tournament extension properties

### DIFF
--- a/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/ModelHelper.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/ModelHelper.kt
@@ -42,6 +42,12 @@ object ModelHelper {
         get() = Tournament.StandingsType.entries.firstOrNull { type -> hasTag(type.tag) }
 
     /**
+     * Defines if the tournament is a Danish championship based on the tags
+     */
+    val Tournament.isDanishChampionship: Boolean
+        get() = hasTag(Tournament.Tag.ChampionshipDanish)
+
+    /**
      * Converts a raw event to a simple event
      */
     fun Event.Raw.toDetailedEvent(): Event.Simple {

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/ModelHelper.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/ModelHelper.kt
@@ -35,6 +35,13 @@ object ModelHelper {
         get() = hasTag(Tournament.Tag.StickLeague)
 
     /**
+     * Defines how the tournament's standings are structured based on the tags, or null if no standings tag is present.
+     * The types are mutually exclusive; the first matching tag wins
+     */
+    val Tournament.standingsType: Tournament.StandingsType?
+        get() = Tournament.StandingsType.entries.firstOrNull { type -> hasTag(type.tag) }
+
+    /**
      * Converts a raw event to a simple event
      */
     fun Event.Raw.toDetailedEvent(): Event.Simple {

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/ModelHelper.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/ModelHelper.kt
@@ -17,17 +17,22 @@ object ModelHelper {
     )
 
     /**
+     * Whether the tournament has the given [tag]
+     */
+    fun Tournament.hasTag(tag: Tournament.Tag): Boolean = tags.contains(tag.identifier)
+
+    /**
      * Defines if the tournament is the current stick league based on the tags - this can therefore change from season
      * to season
      */
     val Tournament.isCurrentStickLeague: Boolean
-        get() = tags.contains("stick-league-current")
+        get() = hasTag(Tournament.Tag.StickLeagueCurrent)
 
     /**
      * Defines if the tournament is a stick league tournament (current or past) based on the tags
      */
     val Tournament.isStickLeague: Boolean
-        get() = tags.contains("stick-league")
+        get() = hasTag(Tournament.Tag.StickLeague)
 
     /**
      * Converts a raw event to a simple event

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/Tournament.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/Tournament.kt
@@ -33,7 +33,7 @@ sealed interface Tournament {
     }
 
     /**
-     * Defines how a tournament's standings are structured. The two types are mutually exclusive. Csn be resolved from
+     * Defines how a tournament's standings are structured. The two types are mutually exclusive. Can be resolved from
      * tags via [ModelHelper.standingsType]
      */
     enum class StandingsType(val tag: Tag) {

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/Tournament.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/Tournament.kt
@@ -27,6 +27,17 @@ sealed interface Tournament {
     enum class Tag(val identifier: String) {
         StickLeague("stick-league"),
         StickLeagueCurrent("stick-league-current"),
+        StandingsGameCount("standings-game-count"),
+        StandingsGameTime("standings-game-time"),
+    }
+
+    /**
+     * Defines how a tournament's standings are structured. The two types are mutually exclusive. Resolved from tags via
+     * [ModelHelper.standingsType]
+     */
+    enum class StandingsType(val tag: Tag) {
+        GameCount(Tag.StandingsGameCount),
+        GameTime(Tag.StandingsGameTime),
     }
 
     /**

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/Tournament.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/Tournament.kt
@@ -29,6 +29,7 @@ sealed interface Tournament {
         StickLeagueCurrent("stick-league-current"),
         StandingsGameCount("standings-game-count"),
         StandingsGameTime("standings-game-time"),
+        ChampionshipDanish("championship-danish"),
     }
 
     /**

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/Tournament.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/Tournament.kt
@@ -33,8 +33,8 @@ sealed interface Tournament {
     }
 
     /**
-     * Defines how a tournament's standings are structured. The two types are mutually exclusive. Resolved from tags via
-     * [ModelHelper.standingsType]
+     * Defines how a tournament's standings are structured. The two types are mutually exclusive. Csn be resolved from
+     * tags via [ModelHelper.standingsType]
      */
     enum class StandingsType(val tag: Tag) {
         GameCount(Tag.StandingsGameCount),

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/Tournament.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/Tournament.kt
@@ -22,6 +22,14 @@ sealed interface Tournament {
     val gameRulesId: GameRules.Id?
 
     /**
+     * Known tags that can be applied to a tournament via [tags]. Use [ModelHelper.hasTag] to check for presence
+     */
+    enum class Tag(val identifier: String) {
+        StickLeague("stick-league"),
+        StickLeagueCurrent("stick-league-current"),
+    }
+
+    /**
      * Id of a tournament. Can be used to reference a tournament without having to care about the tournament game data
      */
     @JvmInline


### PR DESCRIPTION
## Summary

Adds extension properties to the `Tournament` model:

- **`Tournament.Tag` enum + `hasTag` helper** — typed tags on a tournament with a convenience lookup.
- **Tournament `standings` type** — a structured standings representation.
- **Danish championship flag** — marks a tournament as a Danish championship.

## Changes

- `Tournament.kt` — new `Tag` enum, `standings` type, and Danish championship flag.
- `ModelHelper.kt` — `hasTag` helper and supporting wiring.

https://claude.ai/code/session_018oHh3fVvHZ3fPdwGGzihod

---
_Generated by [Claude Code](https://claude.ai/code/session_018oHh3fVvHZ3fPdwGGzihod)_