### PR TITLE
Add per-event removable/updatable flags and RefereeAction.Update

### DIFF
--- a/library/src/commonMain/kotlin/dk/spilpind/sms/api/RequestSerializerInterceptor.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/api/RequestSerializerInterceptor.kt
@@ -131,7 +131,7 @@ object RequestSerializerInterceptor : JsonTransformingSerializer<Request>(Reques
                     Action.Inform -> null
                     Action.Add -> RefereeAction.Add.serializer()
                     Action.Remove -> RefereeAction.Remove.serializer()
-                    Action.Update -> null
+                    Action.Update -> RefereeAction.Update.serializer()
                     Action.Accept -> null
                     Action.Subscribe -> RefereeAction.Subscribe.serializer()
                     Action.Unsubscribe -> RefereeAction.Unsubscribe.serializer()

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/api/action/RefereeAction.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/api/action/RefereeAction.kt
@@ -40,6 +40,24 @@ sealed class RefereeAction : ContextAction() {
     }
 
     /**
+     * Updates the event identified by [eventId] with the values provided. [typeId] should match the core type ids (see
+     * [Event.typeId]) and [time] is the relative seconds within the game the event happened (see [Event.time]). [points]
+     * is only required to be non-null for [Event.Points]. It is important to consider all values even though you're not
+     * allowed to change them, as for instance a value set to null will be updated to that value. Whether an event can be
+     * updated (and what may actually be changed) is decided by the backend, see [RefereeReaction.Event.updatable]. A
+     * successful response to this would be [RefereeReaction.Updated]
+     */
+    @Serializable
+    data class Update(
+        val eventId: Int,
+        val typeId: Int,
+        val time: Int,
+        val points: Int? = null
+    ) : RefereeAction() {
+        override val action: Action = Action.Update
+    }
+
+    /**
      * Subscribes to the game identified by [gameId]. The subscription will be kept alive until the session is destroyed
      * or [Unsubscribe] is called. Changes to the game will be sent via relevant [RefereeReaction]s. A successful
      * response to this would be [RefereeReaction.Subscribed] followed by [RefereeReaction.Updated]

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/api/action/RefereeAction.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/api/action/RefereeAction.kt
@@ -31,8 +31,9 @@ sealed class RefereeAction : ContextAction() {
     }
 
     /**
-     * Removes the event identified by [eventId]. This has to be the last event in the game. A successful response to
-     * this would be [RefereeReaction.Updated]
+     * Removes the event identified by [eventId]. The event has to be removable, see
+     * [RefereeReaction.Event.removable], which the backend decides on a per-event basis. A successful response to this
+     * would be [RefereeReaction.Updated]
      */
     @Serializable
     data class Remove(val eventId: Int) : RefereeAction() {

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/api/action/RefereeReaction.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/api/action/RefereeReaction.kt
@@ -61,7 +61,10 @@ sealed class RefereeReaction : ContextReaction() {
     }
 
     /**
-     * Represents a single event. For more info, see [Raw]
+     * Represents a single event. For more info, see [Raw]. [removable] and [updatable] indicate whether the event can
+     * currently be removed (via [RefereeAction.Remove]) or updated (via [RefereeAction.Update]) respectively. Both are
+     * determined by the backend at the time of the reaction and might thus be a snapshot in case the rules are e.g.
+     * time-based - the backend always re-validates the actual request
      */
     @Serializable
     data class Event(
@@ -71,6 +74,8 @@ sealed class RefereeReaction : ContextReaction() {
         val time: Int,
         val refereeId: Int,
         val created: LocalDateTime,
-        val points: Int? = null
+        val points: Int? = null,
+        val removable: Boolean,
+        val updatable: Boolean
     )
 }


### PR DESCRIPTION
## Why

When judging a game a referee can currently only remove **the latest** event. This causes a timing problem: deleting a `PauseStart` makes game time jump, because `GameHelper.gameTime` is anchored on the pause event — removing a pause that has been running for e.g. 5 minutes "extends" the game by 5 minutes.

The desired behaviour is that some events are not removable (e.g. `PauseStart`) while others — including events *before* a pause — can be removed or edited, possibly under time-based rules (e.g. "a pause can be removed within 10s").

## Approach

Rather than encoding the rules in the core `Event` model (would pollute it) or in `Permissions.kt` (privilege-only, and a client-side rule reintroduces client/backend version drift), this exposes **per-event flags on the referee reaction** and lets the **backend own the rule logic**. The client just reads the flags to show/hide affordances — no rule duplication, no version drift, and time-based rules are naturally supported (flags are a snapshot; the backend re-validates on the actual request).

This PR is **sms-core (the API contract) only**. The concrete rules live in the backend and are defined separately.

## Changes

- **`RefereeAction.Update`** *(commit 1)* — new action to edit an existing event's `typeId`, `time` and `points`, mirroring `Add` and the full-replacement `Update` convention from `GameAction`/`TeamAction`. Registered for deserialization in `RequestSerializerInterceptor`.
- **`removable` / `updatable` flags** *(commit 2)* — added to `RefereeReaction.Event` so the backend can indicate per event whether `Remove`/`Update` are allowed. The `Remove` action doc now references `removable` instead of the old "must be the last event" rule. Flag names mirror `Action.Remove` / `Action.Update`.

The core `Event` model, `GameHelper` and `Permissions` are untouched.

## Notes for follow-up (not in this PR)

- The flags are non-nullable with no default, so the **backend must populate them** before it compiles against this core version (intended forcing function).
- The client should handle an error reaction gracefully if it attempts a `Remove`/`Update` the backend rejects (stale-flag case).

## Verification

`:SmsCore:compileKotlinJvm` passes. The project has no test sources, so there were no tests to run.

https://claude.ai/code/session_012s4XvLj3YYV1mzx6LcPUhg

---
_Generated by [Claude Code](https://claude.ai/code/session_012s4XvLj3YYV1mzx6LcPUhg)_