### PR TITLE
Add Game.Extended variant (tournament + teams resolved, rules by id)

### DIFF
--- a/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/Game.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/Game.kt
@@ -97,7 +97,29 @@ sealed interface Game {
     ) : Typed
 
     /**
-     * Like [Simple] with actual representations of tournament, the teams and the optionally attached rules
+     * Like [Simple] with actual representations of tournament and the teams
+     */
+    data class Extended(
+        override val gameId: Id,
+        val tournament: Tournament,
+        val teamA: Team?,
+        val teamB: Team?,
+        override val state: State,
+        override val teamAPoints: Int,
+        override val teamBPoints: Int,
+        override val elapsedTime: Duration,
+        override val description: String,
+        override val gameRulesId: GameRules.Id?,
+        override val teamJoinInviteCode: String?,
+        override val refereeInviteCode: String?
+    ) : Typed {
+        override val tournamentId = tournament.tournamentId
+        override val teamAId = teamA?.teamId
+        override val teamBId = teamB?.teamId
+    }
+
+    /**
+     * Like [Extended] with an actual representation of the attached rules as well
      */
     data class Detailed(
         override val gameId: Id,

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/ModelHelper.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/ModelHelper.kt
@@ -132,8 +132,8 @@ object ModelHelper {
     )
 
     /**
-     * Converts a simple game to an extended game. It is expected that the provided parameters matches the properties of
-     * the simple game
+     * Converts a typed game to an extended game. It is expected that the provided parameters matches the properties of
+     * the typed game
      */
     fun Game.Typed.toExtendedGame(
         tournament: Tournament,
@@ -174,9 +174,9 @@ object ModelHelper {
     )
 
     /**
-     * Converts a typed game to a simple game
+     * Converts a typed game to a simple game. If it's already a simple game it's returned as-is
      */
-    fun Game.Typed.toSimpleGame() = Game.Simple(
+    fun Game.Typed.toSimpleGame() = this as? Game.Simple ?: Game.Simple(
         gameId = gameId,
         tournamentId = tournamentId,
         teamAId = teamAId,

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/ModelHelper.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/ModelHelper.kt
@@ -132,9 +132,51 @@ object ModelHelper {
     )
 
     /**
-     * Converts a detailed game to a simple game
+     * Converts a simple game to an extended game. It is expected that the provided parameters matches the properties of
+     * the simple game
      */
-    fun Game.Detailed.toSimpleGame() = Game.Simple(
+    fun Game.Typed.toExtendedGame(
+        tournament: Tournament,
+        teamA: Team?,
+        teamB: Team?,
+    ) = Game.Extended(
+        gameId = gameId,
+        tournament = tournament,
+        teamA = teamA,
+        teamB = teamB,
+        state = state,
+        teamAPoints = teamAPoints,
+        teamBPoints = teamBPoints,
+        elapsedTime = elapsedTime,
+        description = description,
+        gameRulesId = gameRulesId,
+        teamJoinInviteCode = teamJoinInviteCode,
+        refereeInviteCode = refereeInviteCode
+    )
+
+    /**
+     * Converts an extended game to a detailed game. It is expected that the provided rules matches the properties of
+     * the extended game
+     */
+    fun Game.Extended.toDetailedGame(rules: GameRules?) = Game.Detailed(
+        gameId = gameId,
+        tournament = tournament,
+        teamA = teamA,
+        teamB = teamB,
+        state = state,
+        teamAPoints = teamAPoints,
+        teamBPoints = teamBPoints,
+        elapsedTime = elapsedTime,
+        description = description,
+        rules = rules,
+        teamJoinInviteCode = teamJoinInviteCode,
+        refereeInviteCode = refereeInviteCode
+    )
+
+    /**
+     * Converts a typed game to a simple game
+     */
+    fun Game.Typed.toSimpleGame() = Game.Simple(
         gameId = gameId,
         tournamentId = tournamentId,
         teamAId = teamAId,


### PR DESCRIPTION
## What & why

Adds a new `Game` variant that sits **between `Simple` and `Detailed`**: it resolves the **tournament and teams** as actual objects but keeps the attached **rules referenced by id only** (`gameRulesId`).

This fills a gap where a caller wants a game's tournament and teams without also loading its rules. Today the only resolved variant is `Detailed`, which forces a `rules` value — so list-style use cases end up passing a placeholder `rules`, which misrepresents "rules not loaded" as "no rules". `Extended` models that intermediate level directly.

## Changes

**`Game.kt`** — new `data class Extended` under the `Typed` sealed interface, placed between `Simple` and `Detailed`:
- Carries `tournament: Tournament`, `teamA: Team?`, `teamB: Team?` (deriving `tournamentId`/`teamAId`/`teamBId`, like `Detailed`).
- Keeps `gameRulesId: GameRules.Id?` as a direct property (like `Simple`/`Raw`).
- KDoc worded like `Detailed` words tournament/teams; `Detailed`'s KDoc rechained so the progression reads `Raw → Simple → Extended → Detailed`.
- Variants kept flat (no data-class inheritance).

**`ModelHelper.kt`** — conversions, with downcasts generalized onto `Game.Typed` to avoid one helper per variant:
- Generalized `Game.Detailed.toSimpleGame()` → `Game.Typed.toSimpleGame()` (source-compatible; covers `Simple`/`Extended`/`Detailed`).
- New `Game.Typed.toExtendedGame(tournament, teamA, teamB)`.
- New `Game.Extended.toDetailedGame(rules)` (kept on `Extended` so it forwards the already-resolved tournament/teams and only needs `rules`).
- Existing `Game.Raw.toSimpleGame()` and `Game.Simple.toDetailedGame(...)` left untouched.

## Compatibility

- No exhaustive `when` over `Game` subtypes exists, so no call sites break. `GameHelper`/`Permissions` only declare extension functions on specific variants.
- API layer unaffected: `GameReaction.Game` is a flat, ids-only DTO and `Game` model subtypes aren't serialized polymorphically. `Extended` is purely a client-side enrichment level.

## Verification

Compiled `:SmsCore:compileKotlinJvm` (with a JDK 17 toolchain) — passes. The library module has no test sources, so none were added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012yjpKJmuo1fnQ43nJr4bHQ)_