### PR TITLE
Add GameGrouping and TeamAdvancement for tournament structure

### DIFF
--- a/library/src/commonMain/kotlin/dk/spilpind/sms/api/RequestSerializerInterceptor.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/api/RequestSerializerInterceptor.kt
@@ -115,6 +115,18 @@ object RequestSerializerInterceptor : JsonTransformingSerializer<Request>(Reques
                     Action.RevokeRequest -> null
                     Action.AcceptRequest -> null
                 }
+                Context.GameGrouping -> when (action) {
+                    Action.Inform -> null
+                    Action.Add -> GameGroupingAction.Add.serializer()
+                    Action.Remove -> GameGroupingAction.Remove.serializer()
+                    Action.Update -> GameGroupingAction.Update.serializer()
+                    Action.Accept -> null
+                    Action.Subscribe -> GameGroupingAction.Subscribe.serializer()
+                    Action.Unsubscribe -> GameGroupingAction.Unsubscribe.serializer()
+                    Action.CreateRequest -> null
+                    Action.RevokeRequest -> null
+                    Action.AcceptRequest -> null
+                }
                 Context.Team -> when (action) {
                     Action.Inform -> null
                     Action.Add -> TeamAction.Add.serializer()

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/api/RequestSerializerInterceptor.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/api/RequestSerializerInterceptor.kt
@@ -127,6 +127,18 @@ object RequestSerializerInterceptor : JsonTransformingSerializer<Request>(Reques
                     Action.RevokeRequest -> null
                     Action.AcceptRequest -> null
                 }
+                Context.TeamAdvancement -> when (action) {
+                    Action.Inform -> null
+                    Action.Add -> TeamAdvancementAction.Add.serializer()
+                    Action.Remove -> TeamAdvancementAction.Remove.serializer()
+                    Action.Update -> TeamAdvancementAction.Update.serializer()
+                    Action.Accept -> null
+                    Action.Subscribe -> TeamAdvancementAction.Subscribe.serializer()
+                    Action.Unsubscribe -> TeamAdvancementAction.Unsubscribe.serializer()
+                    Action.CreateRequest -> null
+                    Action.RevokeRequest -> null
+                    Action.AcceptRequest -> null
+                }
                 Context.Team -> when (action) {
                     Action.Inform -> null
                     Action.Add -> TeamAction.Add.serializer()

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/api/RequestSerializerInterceptor.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/api/RequestSerializerInterceptor.kt
@@ -127,18 +127,6 @@ object RequestSerializerInterceptor : JsonTransformingSerializer<Request>(Reques
                     Action.RevokeRequest -> null
                     Action.AcceptRequest -> null
                 }
-                Context.TeamAdvancement -> when (action) {
-                    Action.Inform -> null
-                    Action.Add -> TeamAdvancementAction.Add.serializer()
-                    Action.Remove -> TeamAdvancementAction.Remove.serializer()
-                    Action.Update -> TeamAdvancementAction.Update.serializer()
-                    Action.Accept -> null
-                    Action.Subscribe -> TeamAdvancementAction.Subscribe.serializer()
-                    Action.Unsubscribe -> TeamAdvancementAction.Unsubscribe.serializer()
-                    Action.CreateRequest -> null
-                    Action.RevokeRequest -> null
-                    Action.AcceptRequest -> null
-                }
                 Context.Team -> when (action) {
                     Action.Inform -> null
                     Action.Add -> TeamAction.Add.serializer()
@@ -150,6 +138,18 @@ object RequestSerializerInterceptor : JsonTransformingSerializer<Request>(Reques
                     Action.CreateRequest -> TeamAction.CreateRequest.serializer()
                     Action.RevokeRequest -> TeamAction.RevokeRequest.serializer()
                     Action.AcceptRequest -> TeamAction.AcceptRequest.serializer()
+                }
+                Context.TeamAdvancement -> when (action) {
+                    Action.Inform -> null
+                    Action.Add -> TeamAdvancementAction.Add.serializer()
+                    Action.Remove -> TeamAdvancementAction.Remove.serializer()
+                    Action.Update -> TeamAdvancementAction.Update.serializer()
+                    Action.Accept -> null
+                    Action.Subscribe -> TeamAdvancementAction.Subscribe.serializer()
+                    Action.Unsubscribe -> TeamAdvancementAction.Unsubscribe.serializer()
+                    Action.CreateRequest -> null
+                    Action.RevokeRequest -> null
+                    Action.AcceptRequest -> null
                 }
                 Context.Referee -> when (action) {
                     Action.Inform -> null

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/api/ResponseSerializerInterceptor.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/api/ResponseSerializerInterceptor.kt
@@ -73,6 +73,7 @@ object ResponseSerializerInterceptor : JsonTransformingSerializer<Response>(Resp
                     Context.Game -> null
                     Context.GameRules -> null
                     Context.GameGrouping -> null
+                    Context.TeamAdvancement -> null
                     Context.Team -> null
                     Context.Referee -> null
                 }
@@ -87,6 +88,7 @@ object ResponseSerializerInterceptor : JsonTransformingSerializer<Response>(Resp
                     Context.Game -> GameReaction.Added.serializer()
                     Context.GameRules -> GameRulesReaction.Added.serializer()
                     Context.GameGrouping -> GameGroupingReaction.Added.serializer()
+                    Context.TeamAdvancement -> TeamAdvancementReaction.Added.serializer()
                     Context.Team -> TeamReaction.Added.serializer()
                     Context.Referee -> null
                 }
@@ -101,6 +103,7 @@ object ResponseSerializerInterceptor : JsonTransformingSerializer<Response>(Resp
                     Context.Game -> GameReaction.Removed.serializer()
                     Context.GameRules -> null
                     Context.GameGrouping -> GameGroupingReaction.Removed.serializer()
+                    Context.TeamAdvancement -> TeamAdvancementReaction.Removed.serializer()
                     Context.Team -> TeamReaction.Removed.serializer()
                     Context.Referee -> null
                 }
@@ -115,6 +118,7 @@ object ResponseSerializerInterceptor : JsonTransformingSerializer<Response>(Resp
                     Context.Game -> GameReaction.Updated.serializer()
                     Context.GameRules -> GameRulesReaction.Updated.serializer()
                     Context.GameGrouping -> GameGroupingReaction.Updated.serializer()
+                    Context.TeamAdvancement -> TeamAdvancementReaction.Updated.serializer()
                     Context.Team -> TeamReaction.Updated.serializer()
                     Context.Referee -> RefereeReaction.Updated.serializer()
                 }
@@ -129,6 +133,7 @@ object ResponseSerializerInterceptor : JsonTransformingSerializer<Response>(Resp
                     Context.Game -> GameReaction.Accepted.serializer()
                     Context.GameRules -> null
                     Context.GameGrouping -> null
+                    Context.TeamAdvancement -> null
                     Context.Team -> null
                     Context.Referee -> null
                 }
@@ -143,6 +148,7 @@ object ResponseSerializerInterceptor : JsonTransformingSerializer<Response>(Resp
                     Context.Game -> GameReaction.Subscribed.serializer()
                     Context.GameRules -> GameRulesReaction.Subscribed.serializer()
                     Context.GameGrouping -> GameGroupingReaction.Subscribed.serializer()
+                    Context.TeamAdvancement -> TeamAdvancementReaction.Subscribed.serializer()
                     Context.Team -> TeamReaction.Subscribed.serializer()
                     Context.Referee -> RefereeReaction.Subscribed.serializer()
                 }
@@ -157,6 +163,7 @@ object ResponseSerializerInterceptor : JsonTransformingSerializer<Response>(Resp
                     Context.Game -> GameReaction.Unsubscribed.serializer()
                     Context.GameRules -> GameRulesReaction.Unsubscribed.serializer()
                     Context.GameGrouping -> GameGroupingReaction.Unsubscribed.serializer()
+                    Context.TeamAdvancement -> TeamAdvancementReaction.Unsubscribed.serializer()
                     Context.Team -> TeamReaction.Unsubscribed.serializer()
                     Context.Referee -> RefereeReaction.Unsubscribed.serializer()
                 }
@@ -171,6 +178,7 @@ object ResponseSerializerInterceptor : JsonTransformingSerializer<Response>(Resp
                     Context.Game -> GameReaction.RequestCreated.serializer()
                     Context.GameRules -> null
                     Context.GameGrouping -> null
+                    Context.TeamAdvancement -> null
                     Context.Team -> TeamReaction.RequestCreated.serializer()
                     Context.Referee -> null
                 }
@@ -185,6 +193,7 @@ object ResponseSerializerInterceptor : JsonTransformingSerializer<Response>(Resp
                     Context.Game -> null
                     Context.GameRules -> null
                     Context.GameGrouping -> null
+                    Context.TeamAdvancement -> null
                     Context.Team -> TeamReaction.RequestRevoked.serializer()
                     Context.Referee -> null
                 }
@@ -199,6 +208,7 @@ object ResponseSerializerInterceptor : JsonTransformingSerializer<Response>(Resp
                     Context.Game -> GameReaction.RequestAccepted.serializer()
                     Context.GameRules -> null
                     Context.GameGrouping -> null
+                    Context.TeamAdvancement -> null
                     Context.Team -> TeamReaction.RequestAccepted.serializer()
                     Context.Referee -> null
                 }

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/api/ResponseSerializerInterceptor.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/api/ResponseSerializerInterceptor.kt
@@ -73,8 +73,8 @@ object ResponseSerializerInterceptor : JsonTransformingSerializer<Response>(Resp
                     Context.Game -> null
                     Context.GameRules -> null
                     Context.GameGrouping -> null
-                    Context.TeamAdvancement -> null
                     Context.Team -> null
+                    Context.TeamAdvancement -> null
                     Context.Referee -> null
                 }
             }
@@ -88,8 +88,8 @@ object ResponseSerializerInterceptor : JsonTransformingSerializer<Response>(Resp
                     Context.Game -> GameReaction.Added.serializer()
                     Context.GameRules -> GameRulesReaction.Added.serializer()
                     Context.GameGrouping -> GameGroupingReaction.Added.serializer()
-                    Context.TeamAdvancement -> TeamAdvancementReaction.Added.serializer()
                     Context.Team -> TeamReaction.Added.serializer()
+                    Context.TeamAdvancement -> TeamAdvancementReaction.Added.serializer()
                     Context.Referee -> null
                 }
             }
@@ -103,8 +103,8 @@ object ResponseSerializerInterceptor : JsonTransformingSerializer<Response>(Resp
                     Context.Game -> GameReaction.Removed.serializer()
                     Context.GameRules -> null
                     Context.GameGrouping -> GameGroupingReaction.Removed.serializer()
-                    Context.TeamAdvancement -> TeamAdvancementReaction.Removed.serializer()
                     Context.Team -> TeamReaction.Removed.serializer()
+                    Context.TeamAdvancement -> TeamAdvancementReaction.Removed.serializer()
                     Context.Referee -> null
                 }
             }
@@ -118,8 +118,8 @@ object ResponseSerializerInterceptor : JsonTransformingSerializer<Response>(Resp
                     Context.Game -> GameReaction.Updated.serializer()
                     Context.GameRules -> GameRulesReaction.Updated.serializer()
                     Context.GameGrouping -> GameGroupingReaction.Updated.serializer()
-                    Context.TeamAdvancement -> TeamAdvancementReaction.Updated.serializer()
                     Context.Team -> TeamReaction.Updated.serializer()
+                    Context.TeamAdvancement -> TeamAdvancementReaction.Updated.serializer()
                     Context.Referee -> RefereeReaction.Updated.serializer()
                 }
             }
@@ -133,8 +133,8 @@ object ResponseSerializerInterceptor : JsonTransformingSerializer<Response>(Resp
                     Context.Game -> GameReaction.Accepted.serializer()
                     Context.GameRules -> null
                     Context.GameGrouping -> null
-                    Context.TeamAdvancement -> null
                     Context.Team -> null
+                    Context.TeamAdvancement -> null
                     Context.Referee -> null
                 }
             }
@@ -148,8 +148,8 @@ object ResponseSerializerInterceptor : JsonTransformingSerializer<Response>(Resp
                     Context.Game -> GameReaction.Subscribed.serializer()
                     Context.GameRules -> GameRulesReaction.Subscribed.serializer()
                     Context.GameGrouping -> GameGroupingReaction.Subscribed.serializer()
-                    Context.TeamAdvancement -> TeamAdvancementReaction.Subscribed.serializer()
                     Context.Team -> TeamReaction.Subscribed.serializer()
+                    Context.TeamAdvancement -> TeamAdvancementReaction.Subscribed.serializer()
                     Context.Referee -> RefereeReaction.Subscribed.serializer()
                 }
             }
@@ -163,8 +163,8 @@ object ResponseSerializerInterceptor : JsonTransformingSerializer<Response>(Resp
                     Context.Game -> GameReaction.Unsubscribed.serializer()
                     Context.GameRules -> GameRulesReaction.Unsubscribed.serializer()
                     Context.GameGrouping -> GameGroupingReaction.Unsubscribed.serializer()
-                    Context.TeamAdvancement -> TeamAdvancementReaction.Unsubscribed.serializer()
                     Context.Team -> TeamReaction.Unsubscribed.serializer()
+                    Context.TeamAdvancement -> TeamAdvancementReaction.Unsubscribed.serializer()
                     Context.Referee -> RefereeReaction.Unsubscribed.serializer()
                 }
             }
@@ -178,8 +178,8 @@ object ResponseSerializerInterceptor : JsonTransformingSerializer<Response>(Resp
                     Context.Game -> GameReaction.RequestCreated.serializer()
                     Context.GameRules -> null
                     Context.GameGrouping -> null
-                    Context.TeamAdvancement -> null
                     Context.Team -> TeamReaction.RequestCreated.serializer()
+                    Context.TeamAdvancement -> null
                     Context.Referee -> null
                 }
             }
@@ -193,8 +193,8 @@ object ResponseSerializerInterceptor : JsonTransformingSerializer<Response>(Resp
                     Context.Game -> null
                     Context.GameRules -> null
                     Context.GameGrouping -> null
-                    Context.TeamAdvancement -> null
                     Context.Team -> TeamReaction.RequestRevoked.serializer()
+                    Context.TeamAdvancement -> null
                     Context.Referee -> null
                 }
             }
@@ -208,8 +208,8 @@ object ResponseSerializerInterceptor : JsonTransformingSerializer<Response>(Resp
                     Context.Game -> GameReaction.RequestAccepted.serializer()
                     Context.GameRules -> null
                     Context.GameGrouping -> null
-                    Context.TeamAdvancement -> null
                     Context.Team -> TeamReaction.RequestAccepted.serializer()
+                    Context.TeamAdvancement -> null
                     Context.Referee -> null
                 }
             }

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/api/ResponseSerializerInterceptor.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/api/ResponseSerializerInterceptor.kt
@@ -72,6 +72,7 @@ object ResponseSerializerInterceptor : JsonTransformingSerializer<Response>(Resp
                     Context.Tournament -> null
                     Context.Game -> null
                     Context.GameRules -> null
+                    Context.GameGrouping -> null
                     Context.Team -> null
                     Context.Referee -> null
                 }
@@ -85,6 +86,7 @@ object ResponseSerializerInterceptor : JsonTransformingSerializer<Response>(Resp
                     Context.Tournament -> TournamentReaction.Added.serializer()
                     Context.Game -> GameReaction.Added.serializer()
                     Context.GameRules -> GameRulesReaction.Added.serializer()
+                    Context.GameGrouping -> GameGroupingReaction.Added.serializer()
                     Context.Team -> TeamReaction.Added.serializer()
                     Context.Referee -> null
                 }
@@ -98,6 +100,7 @@ object ResponseSerializerInterceptor : JsonTransformingSerializer<Response>(Resp
                     Context.Tournament -> TournamentReaction.Removed.serializer()
                     Context.Game -> GameReaction.Removed.serializer()
                     Context.GameRules -> null
+                    Context.GameGrouping -> GameGroupingReaction.Removed.serializer()
                     Context.Team -> TeamReaction.Removed.serializer()
                     Context.Referee -> null
                 }
@@ -111,6 +114,7 @@ object ResponseSerializerInterceptor : JsonTransformingSerializer<Response>(Resp
                     Context.Tournament -> TournamentReaction.Updated.serializer()
                     Context.Game -> GameReaction.Updated.serializer()
                     Context.GameRules -> GameRulesReaction.Updated.serializer()
+                    Context.GameGrouping -> GameGroupingReaction.Updated.serializer()
                     Context.Team -> TeamReaction.Updated.serializer()
                     Context.Referee -> RefereeReaction.Updated.serializer()
                 }
@@ -124,6 +128,7 @@ object ResponseSerializerInterceptor : JsonTransformingSerializer<Response>(Resp
                     Context.Tournament -> null
                     Context.Game -> GameReaction.Accepted.serializer()
                     Context.GameRules -> null
+                    Context.GameGrouping -> null
                     Context.Team -> null
                     Context.Referee -> null
                 }
@@ -137,6 +142,7 @@ object ResponseSerializerInterceptor : JsonTransformingSerializer<Response>(Resp
                     Context.Tournament -> TournamentReaction.Subscribed.serializer()
                     Context.Game -> GameReaction.Subscribed.serializer()
                     Context.GameRules -> GameRulesReaction.Subscribed.serializer()
+                    Context.GameGrouping -> GameGroupingReaction.Subscribed.serializer()
                     Context.Team -> TeamReaction.Subscribed.serializer()
                     Context.Referee -> RefereeReaction.Subscribed.serializer()
                 }
@@ -150,6 +156,7 @@ object ResponseSerializerInterceptor : JsonTransformingSerializer<Response>(Resp
                     Context.Tournament -> TournamentReaction.Unsubscribed.serializer()
                     Context.Game -> GameReaction.Unsubscribed.serializer()
                     Context.GameRules -> GameRulesReaction.Unsubscribed.serializer()
+                    Context.GameGrouping -> GameGroupingReaction.Unsubscribed.serializer()
                     Context.Team -> TeamReaction.Unsubscribed.serializer()
                     Context.Referee -> RefereeReaction.Unsubscribed.serializer()
                 }
@@ -163,6 +170,7 @@ object ResponseSerializerInterceptor : JsonTransformingSerializer<Response>(Resp
                     Context.Tournament -> null
                     Context.Game -> GameReaction.RequestCreated.serializer()
                     Context.GameRules -> null
+                    Context.GameGrouping -> null
                     Context.Team -> TeamReaction.RequestCreated.serializer()
                     Context.Referee -> null
                 }
@@ -176,6 +184,7 @@ object ResponseSerializerInterceptor : JsonTransformingSerializer<Response>(Resp
                     Context.Tournament -> null
                     Context.Game -> null
                     Context.GameRules -> null
+                    Context.GameGrouping -> null
                     Context.Team -> TeamReaction.RequestRevoked.serializer()
                     Context.Referee -> null
                 }
@@ -189,6 +198,7 @@ object ResponseSerializerInterceptor : JsonTransformingSerializer<Response>(Resp
                     Context.Tournament -> null
                     Context.Game -> GameReaction.RequestAccepted.serializer()
                     Context.GameRules -> null
+                    Context.GameGrouping -> null
                     Context.Team -> TeamReaction.RequestAccepted.serializer()
                     Context.Referee -> null
                 }

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/api/action/GameAction.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/api/action/GameAction.kt
@@ -23,6 +23,7 @@ sealed class GameAction : ContextAction() {
         val teamBId: Int?,
         val description: String,
         val gameRulesId: Int? = null,
+        val gameGroupingId: Int? = null,
         val addTeamJoinInvite: Boolean = false
     ) : GameAction() {
         override val action: Action = Action.Add
@@ -48,6 +49,7 @@ sealed class GameAction : ContextAction() {
         val teamBId: Int?,
         val description: String,
         val gameRulesId: Int?,
+        val gameGroupingId: Int? = null,
     ) : GameAction() {
         override val action: Action = Action.Update
     }

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/api/action/GameGroupingAction.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/api/action/GameGroupingAction.kt
@@ -1,0 +1,71 @@
+package dk.spilpind.sms.api.action
+
+import dk.spilpind.sms.api.common.Action
+import dk.spilpind.sms.core.model.Context
+import kotlinx.serialization.Serializable
+
+/**
+ * All possible actions that can be made in relation to [Context.GameGrouping]
+ */
+@Serializable
+sealed class GameGroupingAction : ContextAction() {
+    override val context: Context = Context.GameGrouping
+
+    /**
+     * Adds a new game grouping associated with the tournament identified by [tournamentId]. [level] describes how far
+     * into the tournament the grouping is, where a lower value is more important (e.g. 1 represents the final). A
+     * successful response to this would be [GameGroupingReaction.Added]
+     */
+    @Serializable
+    data class Add(
+        val tournamentId: Int,
+        val name: String,
+        val level: Int,
+    ) : GameGroupingAction() {
+        override val action: Action = Action.Add
+    }
+
+    /**
+     * Removes the game grouping with id [gameGroupingId]. A successful response to this would be
+     * [GameGroupingReaction.Removed]
+     */
+    @Serializable
+    data class Remove(val gameGroupingId: Int) : GameGroupingAction() {
+        override val action: Action = Action.Remove
+    }
+
+    /**
+     * Updates the game grouping with id [gameGroupingId] with the values provided. It is important to consider all
+     * values even though you're not allowed to change them, as for instance a value set to empty or null will be
+     * updated to that value
+     */
+    @Serializable
+    data class Update(
+        val gameGroupingId: Int,
+        val name: String,
+        val level: Int,
+    ) : GameGroupingAction() {
+        override val action: Action = Action.Update
+    }
+
+    /**
+     * Subscribes either to all game groupings associated with the specific [tournamentId] or the single game grouping
+     * associated with [gameGroupingId] (both cannot be specified). The subscription will be kept alive until the
+     * session is destroyed or [Unsubscribe] is called. Changes to the list will be sent via relevant
+     * [GameGroupingReaction]s. A successful response to this would be [GameGroupingReaction.Subscribed] followed by
+     * [GameGroupingReaction.Updated]
+     */
+    @Serializable
+    data class Subscribe(val gameGroupingId: Int? = null, val tournamentId: Int? = null) : GameGroupingAction() {
+        override val action: Action = Action.Subscribe
+    }
+
+    /**
+     * Unsubscribes the socket from updates to the list of game groupings, previously subscribed by [Subscribe]. A
+     * successful response to this would be [GameGroupingReaction.Unsubscribed]
+     */
+    @Serializable
+    data class Unsubscribe(val gameGroupingId: Int? = null, val tournamentId: Int? = null) : GameGroupingAction() {
+        override val action: Action = Action.Unsubscribe
+    }
+}

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/api/action/GameGroupingReaction.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/api/action/GameGroupingReaction.kt
@@ -1,0 +1,68 @@
+package dk.spilpind.sms.api.action
+
+import dk.spilpind.sms.core.model.Context
+import dk.spilpind.sms.api.common.Reaction
+import kotlinx.serialization.Serializable
+
+/**
+ * All possible reactions that can be made in relation to [Context.GameGrouping]
+ */
+@Serializable
+sealed class GameGroupingReaction : ContextReaction() {
+    override val context: Context = Context.GameGrouping
+
+    /**
+     * Response to [GameGroupingAction.Add] and updates via subscriptions
+     */
+    @Serializable
+    data class Added(val gameGrouping: GameGrouping) : GameGroupingReaction() {
+        override val reaction: Reaction = Reaction.Added
+    }
+
+    /**
+     * Response to [GameGroupingAction.Remove] and updates via subscriptions
+     */
+    @Serializable
+    data class Removed(val gameGroupingId: Int) : GameGroupingReaction() {
+        override val reaction: Reaction = Reaction.Removed
+    }
+
+    /**
+     * Response to changes in one or more of the game groupings. If [allGameGroupings] is false, only the listed game
+     * groupings should be updated - if it's true, the entire list should be replaced
+     */
+    @Serializable
+    data class Updated(
+        val allGameGroupings: Boolean,
+        val gameGroupings: List<GameGrouping>
+    ) : GameGroupingReaction() {
+        override val reaction: Reaction = Reaction.Updated
+    }
+
+    /**
+     * Response to [GameGroupingAction.Subscribe]
+     */
+    @Serializable
+    class Subscribed : GameGroupingReaction() {
+        override val reaction: Reaction = Reaction.Subscribed
+    }
+
+    /**
+     * Response to [GameGroupingAction.Unsubscribe]
+     */
+    @Serializable
+    class Unsubscribed : GameGroupingReaction() {
+        override val reaction: Reaction = Reaction.Unsubscribed
+    }
+
+    /**
+     * Represents a single game grouping
+     */
+    @Serializable
+    data class GameGrouping(
+        val gameGroupingId: Int,
+        val tournamentId: Int,
+        val name: String,
+        val level: Int,
+    )
+}

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/api/action/GameReaction.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/api/action/GameReaction.kt
@@ -98,6 +98,7 @@ sealed class GameReaction : ContextReaction() {
         val elapsedTime: Duration,
         val description: String,
         val gameRulesId: Int?,
+        val gameGroupingId: Int? = null,
         val teamJoinInviteCode: String? = null,
         val refereeInviteCode: String? = null
     )

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/api/action/GameReaction.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/api/action/GameReaction.kt
@@ -98,7 +98,7 @@ sealed class GameReaction : ContextReaction() {
         val elapsedTime: Duration,
         val description: String,
         val gameRulesId: Int?,
-        val gameGroupingId: Int? = null,
+        val gameGroupingId: Int?,
         val teamJoinInviteCode: String? = null,
         val refereeInviteCode: String? = null
     )

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/api/action/TeamAdvancementAction.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/api/action/TeamAdvancementAction.kt
@@ -1,0 +1,89 @@
+package dk.spilpind.sms.api.action
+
+import dk.spilpind.sms.api.common.Action
+import dk.spilpind.sms.core.model.Context
+import kotlinx.serialization.Serializable
+
+/**
+ * All possible actions that can be made in relation to [Context.TeamAdvancement].
+ *
+ * Both ends of an advancement are referenced via a type + id pair: [Add.sourceType]/[Add.sourceId] and
+ * [Add.destinationType]/[Add.destinationId], where the type is either `"game"` or `"gameGrouping"`
+ */
+@Serializable
+sealed class TeamAdvancementAction : ContextAction() {
+    override val context: Context = Context.TeamAdvancement
+
+    /**
+     * Adds a new team advancement scoped to the tournament identified by [tournamentId]. The team with
+     * [sourcePlacement] in the source (identified by [sourceType] and [sourceId]) is meant to be transferred to the
+     * destination (identified by [destinationType] and [destinationId]). A successful response to this would be
+     * [TeamAdvancementReaction.Added]
+     */
+    @Serializable
+    data class Add(
+        val tournamentId: Int,
+        val sourceType: String,
+        val sourceId: Int,
+        val sourcePlacement: Int,
+        val destinationType: String,
+        val destinationId: Int,
+    ) : TeamAdvancementAction() {
+        override val action: Action = Action.Add
+    }
+
+    /**
+     * Removes the team advancement with id [teamAdvancementId]. A successful response to this would be
+     * [TeamAdvancementReaction.Removed]
+     */
+    @Serializable
+    data class Remove(val teamAdvancementId: Int) : TeamAdvancementAction() {
+        override val action: Action = Action.Remove
+    }
+
+    /**
+     * Updates the team advancement with id [teamAdvancementId] with the values provided. It is important to consider all
+     * values even though you're not allowed to change them, as for instance a value set to empty or null will be
+     * updated to that value
+     */
+    @Serializable
+    data class Update(
+        val teamAdvancementId: Int,
+        val sourceType: String,
+        val sourceId: Int,
+        val sourcePlacement: Int,
+        val destinationType: String,
+        val destinationId: Int,
+    ) : TeamAdvancementAction() {
+        override val action: Action = Action.Update
+    }
+
+    /**
+     * Subscribes to team advancements associated with the given parameters: all advancements of a [tournamentId], or
+     * those referencing a specific [gameId] or [gameGroupingId]. The subscription will be kept alive until the session
+     * is destroyed or [Unsubscribe] is called. Changes to the list will be sent via relevant
+     * [TeamAdvancementReaction]s. A successful response to this would be [TeamAdvancementReaction.Subscribed] followed
+     * by [TeamAdvancementReaction.Updated]
+     */
+    @Serializable
+    data class Subscribe(
+        val tournamentId: Int? = null,
+        val gameId: Int? = null,
+        val gameGroupingId: Int? = null,
+    ) : TeamAdvancementAction() {
+        override val action: Action = Action.Subscribe
+    }
+
+    /**
+     * Unsubscribes the socket from updates to the list of team advancements, previously subscribed by [Subscribe]. A
+     * successful response to this would be [TeamAdvancementReaction.Unsubscribed]
+     */
+    @Serializable
+    data class Unsubscribe(
+        val tournamentId: Int? = null,
+        val gameId: Int? = null,
+        val gameGroupingId: Int? = null,
+    ) : TeamAdvancementAction() {
+        override val action: Action = Action.Unsubscribe
+    }
+}

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/api/action/TeamAdvancementReaction.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/api/action/TeamAdvancementReaction.kt
@@ -1,0 +1,72 @@
+package dk.spilpind.sms.api.action
+
+import dk.spilpind.sms.core.model.Context
+import dk.spilpind.sms.api.common.Reaction
+import kotlinx.serialization.Serializable
+
+/**
+ * All possible reactions that can be made in relation to [Context.TeamAdvancement]
+ */
+@Serializable
+sealed class TeamAdvancementReaction : ContextReaction() {
+    override val context: Context = Context.TeamAdvancement
+
+    /**
+     * Response to [TeamAdvancementAction.Add] and updates via subscriptions
+     */
+    @Serializable
+    data class Added(val teamAdvancement: TeamAdvancement) : TeamAdvancementReaction() {
+        override val reaction: Reaction = Reaction.Added
+    }
+
+    /**
+     * Response to [TeamAdvancementAction.Remove] and updates via subscriptions
+     */
+    @Serializable
+    data class Removed(val teamAdvancementId: Int) : TeamAdvancementReaction() {
+        override val reaction: Reaction = Reaction.Removed
+    }
+
+    /**
+     * Response to changes in one or more of the team advancements. If [allTeamAdvancements] is false, only the listed
+     * team advancements should be updated - if it's true, the entire list should be replaced
+     */
+    @Serializable
+    data class Updated(
+        val allTeamAdvancements: Boolean,
+        val teamAdvancements: List<TeamAdvancement>
+    ) : TeamAdvancementReaction() {
+        override val reaction: Reaction = Reaction.Updated
+    }
+
+    /**
+     * Response to [TeamAdvancementAction.Subscribe]
+     */
+    @Serializable
+    class Subscribed : TeamAdvancementReaction() {
+        override val reaction: Reaction = Reaction.Subscribed
+    }
+
+    /**
+     * Response to [TeamAdvancementAction.Unsubscribe]
+     */
+    @Serializable
+    class Unsubscribed : TeamAdvancementReaction() {
+        override val reaction: Reaction = Reaction.Unsubscribed
+    }
+
+    /**
+     * Represents a single team advancement. Both ends are referenced via a type + id pair, where the type
+     * ([sourceType]/[destinationType]) is either `"game"` or `"gameGrouping"`
+     */
+    @Serializable
+    data class TeamAdvancement(
+        val teamAdvancementId: Int,
+        val tournamentId: Int,
+        val sourceType: String,
+        val sourceId: Int,
+        val sourcePlacement: Int,
+        val destinationType: String,
+        val destinationId: Int,
+    )
+}

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/Context.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/Context.kt
@@ -18,6 +18,7 @@ enum class Context(val contextKey: String) {
     Tournament("tournament"),
     Game("game"),
     GameRules("gameRules"),
+    GameGrouping("gameGrouping"),
     Team("team"),
     Referee("referee"),
 }

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/Context.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/Context.kt
@@ -19,6 +19,7 @@ enum class Context(val contextKey: String) {
     Game("game"),
     GameRules("gameRules"),
     GameGrouping("gameGrouping"),
+    TeamAdvancement("teamAdvancement"),
     Team("team"),
     Referee("referee"),
 }

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/Context.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/Context.kt
@@ -19,7 +19,7 @@ enum class Context(val contextKey: String) {
     Game("game"),
     GameRules("gameRules"),
     GameGrouping("gameGrouping"),
-    TeamAdvancement("teamAdvancement"),
     Team("team"),
+    TeamAdvancement("teamAdvancement"),
     Referee("referee"),
 }

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/Game.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/Game.kt
@@ -23,6 +23,11 @@ sealed interface Game {
      * last resort, via [GameRules.Standard]
      */
     val gameRulesId: GameRules.Custom.Id?
+
+    /**
+     * The game grouping this game belongs to, if any (see [GameGrouping])
+     */
+    val gameGroupingId: GameGrouping.Id?
     val teamJoinInviteCode: String?
     val refereeInviteCode: String?
 
@@ -74,6 +79,7 @@ sealed interface Game {
         override val elapsedTime: Duration,
         override val description: String,
         override val gameRulesId: GameRules.Custom.Id?,
+        override val gameGroupingId: GameGrouping.Id?,
         override val teamJoinInviteCode: String?,
         override val refereeInviteCode: String?
     ) : Game
@@ -92,6 +98,7 @@ sealed interface Game {
         override val elapsedTime: Duration,
         override val description: String,
         override val gameRulesId: GameRules.Custom.Id?,
+        override val gameGroupingId: GameGrouping.Id?,
         override val teamJoinInviteCode: String?,
         override val refereeInviteCode: String?
     ) : Typed
@@ -110,6 +117,7 @@ sealed interface Game {
         override val elapsedTime: Duration,
         override val description: String,
         override val gameRulesId: GameRules.Custom.Id?,
+        override val gameGroupingId: GameGrouping.Id?,
         override val teamJoinInviteCode: String?,
         override val refereeInviteCode: String?
     ) : Typed {
@@ -132,6 +140,7 @@ sealed interface Game {
         override val elapsedTime: Duration,
         override val description: String,
         val effectiveRules: GameRules.Effective,
+        override val gameGroupingId: GameGrouping.Id?,
         override val teamJoinInviteCode: String?,
         override val refereeInviteCode: String?
     ) : Typed {

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/GameGrouping.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/GameGrouping.kt
@@ -1,0 +1,27 @@
+package dk.spilpind.sms.core.model
+
+import kotlin.jvm.JvmInline
+
+/**
+ * Represents a named group of games within a tournament, e.g. an actual group ("Group A") or just a label for a phase
+ * ("Quarterfinals"). [level] describes how far into the tournament the grouping is, where a lower value is more
+ * important - e.g. 1 represents the final
+ */
+data class GameGrouping(
+    val gameGroupingId: Id,
+    val tournamentId: Tournament.Id,
+    val name: String,
+    val level: Int,
+) {
+
+    /**
+     * Id of a game grouping. Can be used to reference a game grouping without having to care about the remaining data
+     */
+    @JvmInline
+    value class Id(override val identifier: Int) : ContextIdentifier, Comparable<Id> {
+
+        override fun compareTo(other: Id): Int =
+            identifier.compareTo(other.identifier)
+
+    }
+}

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/ModelHelper.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/ModelHelper.kt
@@ -103,6 +103,7 @@ object ModelHelper {
         elapsedTime = elapsedTime,
         description = description,
         gameRulesId = gameRulesId,
+        gameGroupingId = gameGroupingId,
         teamJoinInviteCode = teamJoinInviteCode,
         refereeInviteCode = refereeInviteCode
     )
@@ -127,6 +128,7 @@ object ModelHelper {
         elapsedTime = elapsedTime,
         description = description,
         effectiveRules = effectiveRules,
+        gameGroupingId = gameGroupingId,
         teamJoinInviteCode = teamJoinInviteCode,
         refereeInviteCode = refereeInviteCode
     )
@@ -150,6 +152,7 @@ object ModelHelper {
         elapsedTime = elapsedTime,
         description = description,
         gameRulesId = gameRulesId,
+        gameGroupingId = gameGroupingId,
         teamJoinInviteCode = teamJoinInviteCode,
         refereeInviteCode = refereeInviteCode
     )
@@ -171,6 +174,7 @@ object ModelHelper {
         elapsedTime = elapsedTime,
         description = description,
         effectiveRules = effectiveRules,
+        gameGroupingId = gameGroupingId,
         teamJoinInviteCode = teamJoinInviteCode,
         refereeInviteCode = refereeInviteCode
     )
@@ -189,6 +193,7 @@ object ModelHelper {
         elapsedTime = elapsedTime,
         description = description,
         gameRulesId = gameRulesId,
+        gameGroupingId = gameGroupingId,
         teamJoinInviteCode = teamJoinInviteCode,
         refereeInviteCode = refereeInviteCode
     )

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/ModelHelper.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/ModelHelper.kt
@@ -224,6 +224,11 @@ object ModelHelper {
     fun Int.toGameRulesId() = GameRules.Custom.Id(this)
 
     /**
+     * Creates a game grouping id from the integer
+     */
+    fun Int.toGameGroupingId() = GameGrouping.Id(this)
+
+    /**
      * Creates a user id from the integer
      */
     fun Int.toUserId() = User.Id(this)

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/ModelHelper.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/ModelHelper.kt
@@ -234,6 +234,11 @@ object ModelHelper {
     fun Int.toGameGroupingId() = GameGrouping.Id(this)
 
     /**
+     * Creates a team advancement id from the integer
+     */
+    fun Int.toTeamAdvancementId() = TeamAdvancement.Id(this)
+
+    /**
      * Creates a user id from the integer
      */
     fun Int.toUserId() = User.Id(this)

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/TeamAdvancement.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/TeamAdvancement.kt
@@ -1,5 +1,7 @@
 package dk.spilpind.sms.core.model
 
+import dk.spilpind.sms.core.model.Game as GameModel
+import dk.spilpind.sms.core.model.GameGrouping as GameGroupingModel
 import kotlin.jvm.JvmInline
 
 /**
@@ -28,20 +30,19 @@ data class TeamAdvancement(
     }
 
     /**
-     * Reference to either end of a [TeamAdvancement], i.e. what a team is transferred from ([source]) or to
-     * ([destination])
+     * Reference to either end of a [TeamAdvancement], i.e. what a team advances from ([source]) or to ([destination])
      */
     sealed interface Reference {
 
         /**
-         * References a specific game. For a game, [TeamAdvancement.sourcePlacement] is typically 1 (winner) or 2 (loser)
+         * References a specific game. For a game, [TeamAdvancement.sourcePlacement] is 1 (winner) or 2 (loser)
          */
-        data class Game(val gameId: dk.spilpind.sms.core.model.Game.Id) : Reference
+        data class Game(val gameId: GameModel.Id) : Reference
 
         /**
-         * References a specific game grouping. For a grouping, [TeamAdvancement.sourcePlacement] is typically the rank
-         * within the grouping (1..n)
+         * References a specific game grouping. For a grouping, [TeamAdvancement.sourcePlacement] is the rank within the
+         * grouping (e.g. 1 is first place, 3 is third place)
          */
-        data class GameGrouping(val gameGroupingId: dk.spilpind.sms.core.model.GameGrouping.Id) : Reference
+        data class GameGrouping(val gameGroupingId: GameGroupingModel.Id) : Reference
     }
 }

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/TeamAdvancement.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/TeamAdvancement.kt
@@ -1,0 +1,47 @@
+package dk.spilpind.sms.core.model
+
+import kotlin.jvm.JvmInline
+
+/**
+ * Represents how a team is meant to be transferred within a tournament: the team with [sourcePlacement] in [source]
+ * should advance to [destination]. Nothing happens automatically based on this - it only records the intended structure
+ * so it can be displayed (e.g. "winner of the quarterfinal advances to the semifinal")
+ */
+data class TeamAdvancement(
+    val teamAdvancementId: Id,
+    val tournamentId: Tournament.Id,
+    val source: Reference,
+    val sourcePlacement: Int,
+    val destination: Reference,
+) {
+
+    /**
+     * Id of a team advancement. Can be used to reference a team advancement without having to care about the remaining
+     * data
+     */
+    @JvmInline
+    value class Id(override val identifier: Int) : ContextIdentifier, Comparable<Id> {
+
+        override fun compareTo(other: Id): Int =
+            identifier.compareTo(other.identifier)
+
+    }
+
+    /**
+     * Reference to either end of a [TeamAdvancement], i.e. what a team is transferred from ([source]) or to
+     * ([destination])
+     */
+    sealed interface Reference {
+
+        /**
+         * References a specific game. For a game, [TeamAdvancement.sourcePlacement] is typically 1 (winner) or 2 (loser)
+         */
+        data class Game(val gameId: dk.spilpind.sms.core.model.Game.Id) : Reference
+
+        /**
+         * References a specific game grouping. For a grouping, [TeamAdvancement.sourcePlacement] is typically the rank
+         * within the grouping (1..n)
+         */
+        data class GameGrouping(val gameGroupingId: dk.spilpind.sms.core.model.GameGrouping.Id) : Reference
+    }
+}

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/TeamAdvancement.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/TeamAdvancement.kt
@@ -5,9 +5,9 @@ import dk.spilpind.sms.core.model.GameGrouping as GameGroupingModel
 import kotlin.jvm.JvmInline
 
 /**
- * Represents how a team is meant to be transferred within a tournament: the team with [sourcePlacement] in [source]
- * should advance to [destination]. Nothing happens automatically based on this - it only records the intended structure
- * so it can be displayed (e.g. "winner of the quarterfinal advances to the semifinal")
+ * Represents how a team is meant to be advanced within a tournament: the team with [sourcePlacement] in [source] should
+ * advance to [destination]. It records the intended structure so it can be displayed (e.g. "winner of the quarterfinal
+ * advances to the semifinal")
  */
 data class TeamAdvancement(
     val teamAdvancementId: Id,


### PR DESCRIPTION
## Why

A tournament is currently a flat set of games and teams, with no way to express its *structure*: that games belong to a labelled group/phase (e.g. "Group A", "Quarterfinals", "Final"), nor how a team moves from one game/phase to another based on its result. This adds two core concepts so a tournament's structure can be described and shown in the frontend.

## What

**`GameGrouping`** — a named group of games within a tournament with a `level` (lower = more important; 1 = final). Can represent a real group ("Group A") or just a phase label ("Quarterfinals").
- New `GameGrouping` model + `Id`
- New `GameGrouping` context with add/remove/update/subscribe/unsubscribe actions and matching reactions
- Serializer wiring in the request and response interceptors
- `Int.toGameGroupingId()` helper

**`Game.gameGroupingId`** — an optional reference from a game to the grouping it belongs to.
- Nullable `gameGroupingId` on every `Game` variant, the Game add/update actions, and the Game reaction DTO
- Threaded through the `ModelHelper` game converters

**`TeamAdvancement`** — a tournament-scoped link: the team with a given source placement in a source (a game or a game grouping) is meant to be transferred to a destination (a game or a game grouping). Nothing happens automatically — it only records the intended structure so it can be displayed (e.g. "winner of the quarterfinal advances to the semifinal").
- New `TeamAdvancement` model with a nested `Reference` sealed interface (`Game` / `GameGrouping`) for each end, plus `Id`
- On the wire, the action/reaction DTOs flatten a reference into `type` + `id` primitives, consistent with the other reactions
- Subscriptions keyed by tournament, game, or game grouping
- Serializer wiring in both interceptors and a `Int.toTeamAdvancementId()` helper

## Commits

Split into three commits that each compile on their own:
1. Add `GameGrouping` concept
2. Add optional `gameGroupingId` to `Game`
3. Add `TeamAdvancement` concept

## Testing

`Json` round-trip checks through both interceptors for the new actions and reactions (covering both a `game` and a `gameGrouping` reference) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CF5rGBYRrTh2JAjBL64Jha

---
_Generated by [Claude Code](https://claude.ai/code/session_01CF5rGBYRrTh2JAjBL64Jha)_