### PR TITLE
Add a club concept

### DIFF
--- a/library/src/commonMain/kotlin/dk/spilpind/sms/api/RequestSerializerInterceptor.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/api/RequestSerializerInterceptor.kt
@@ -127,6 +127,18 @@ object RequestSerializerInterceptor : JsonTransformingSerializer<Request>(Reques
                     Action.RevokeRequest -> null
                     Action.AcceptRequest -> null
                 }
+                Context.Club -> when (action) {
+                    Action.Inform -> null
+                    Action.Add -> ClubAction.Add.serializer()
+                    Action.Remove -> ClubAction.Remove.serializer()
+                    Action.Update -> ClubAction.Update.serializer()
+                    Action.Accept -> null
+                    Action.Subscribe -> ClubAction.Subscribe.serializer()
+                    Action.Unsubscribe -> ClubAction.Unsubscribe.serializer()
+                    Action.CreateRequest -> null
+                    Action.RevokeRequest -> null
+                    Action.AcceptRequest -> null
+                }
                 Context.Team -> when (action) {
                     Action.Inform -> null
                     Action.Add -> TeamAction.Add.serializer()

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/api/ResponseSerializerInterceptor.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/api/ResponseSerializerInterceptor.kt
@@ -73,6 +73,7 @@ object ResponseSerializerInterceptor : JsonTransformingSerializer<Response>(Resp
                     Context.Game -> null
                     Context.GameRules -> null
                     Context.GameGrouping -> null
+                    Context.Club -> null
                     Context.Team -> null
                     Context.TeamAdvancement -> null
                     Context.Referee -> null
@@ -88,6 +89,7 @@ object ResponseSerializerInterceptor : JsonTransformingSerializer<Response>(Resp
                     Context.Game -> GameReaction.Added.serializer()
                     Context.GameRules -> GameRulesReaction.Added.serializer()
                     Context.GameGrouping -> GameGroupingReaction.Added.serializer()
+                    Context.Club -> ClubReaction.Added.serializer()
                     Context.Team -> TeamReaction.Added.serializer()
                     Context.TeamAdvancement -> TeamAdvancementReaction.Added.serializer()
                     Context.Referee -> null
@@ -103,6 +105,7 @@ object ResponseSerializerInterceptor : JsonTransformingSerializer<Response>(Resp
                     Context.Game -> GameReaction.Removed.serializer()
                     Context.GameRules -> null
                     Context.GameGrouping -> GameGroupingReaction.Removed.serializer()
+                    Context.Club -> ClubReaction.Removed.serializer()
                     Context.Team -> TeamReaction.Removed.serializer()
                     Context.TeamAdvancement -> TeamAdvancementReaction.Removed.serializer()
                     Context.Referee -> null
@@ -118,6 +121,7 @@ object ResponseSerializerInterceptor : JsonTransformingSerializer<Response>(Resp
                     Context.Game -> GameReaction.Updated.serializer()
                     Context.GameRules -> GameRulesReaction.Updated.serializer()
                     Context.GameGrouping -> GameGroupingReaction.Updated.serializer()
+                    Context.Club -> ClubReaction.Updated.serializer()
                     Context.Team -> TeamReaction.Updated.serializer()
                     Context.TeamAdvancement -> TeamAdvancementReaction.Updated.serializer()
                     Context.Referee -> RefereeReaction.Updated.serializer()
@@ -133,6 +137,7 @@ object ResponseSerializerInterceptor : JsonTransformingSerializer<Response>(Resp
                     Context.Game -> GameReaction.Accepted.serializer()
                     Context.GameRules -> null
                     Context.GameGrouping -> null
+                    Context.Club -> null
                     Context.Team -> null
                     Context.TeamAdvancement -> null
                     Context.Referee -> null
@@ -148,6 +153,7 @@ object ResponseSerializerInterceptor : JsonTransformingSerializer<Response>(Resp
                     Context.Game -> GameReaction.Subscribed.serializer()
                     Context.GameRules -> GameRulesReaction.Subscribed.serializer()
                     Context.GameGrouping -> GameGroupingReaction.Subscribed.serializer()
+                    Context.Club -> ClubReaction.Subscribed.serializer()
                     Context.Team -> TeamReaction.Subscribed.serializer()
                     Context.TeamAdvancement -> TeamAdvancementReaction.Subscribed.serializer()
                     Context.Referee -> RefereeReaction.Subscribed.serializer()
@@ -163,6 +169,7 @@ object ResponseSerializerInterceptor : JsonTransformingSerializer<Response>(Resp
                     Context.Game -> GameReaction.Unsubscribed.serializer()
                     Context.GameRules -> GameRulesReaction.Unsubscribed.serializer()
                     Context.GameGrouping -> GameGroupingReaction.Unsubscribed.serializer()
+                    Context.Club -> ClubReaction.Unsubscribed.serializer()
                     Context.Team -> TeamReaction.Unsubscribed.serializer()
                     Context.TeamAdvancement -> TeamAdvancementReaction.Unsubscribed.serializer()
                     Context.Referee -> RefereeReaction.Unsubscribed.serializer()
@@ -178,6 +185,7 @@ object ResponseSerializerInterceptor : JsonTransformingSerializer<Response>(Resp
                     Context.Game -> GameReaction.RequestCreated.serializer()
                     Context.GameRules -> null
                     Context.GameGrouping -> null
+                    Context.Club -> null
                     Context.Team -> TeamReaction.RequestCreated.serializer()
                     Context.TeamAdvancement -> null
                     Context.Referee -> null
@@ -193,6 +201,7 @@ object ResponseSerializerInterceptor : JsonTransformingSerializer<Response>(Resp
                     Context.Game -> null
                     Context.GameRules -> null
                     Context.GameGrouping -> null
+                    Context.Club -> null
                     Context.Team -> TeamReaction.RequestRevoked.serializer()
                     Context.TeamAdvancement -> null
                     Context.Referee -> null
@@ -208,6 +217,7 @@ object ResponseSerializerInterceptor : JsonTransformingSerializer<Response>(Resp
                     Context.Game -> GameReaction.RequestAccepted.serializer()
                     Context.GameRules -> null
                     Context.GameGrouping -> null
+                    Context.Club -> null
                     Context.Team -> TeamReaction.RequestAccepted.serializer()
                     Context.TeamAdvancement -> null
                     Context.Referee -> null

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/api/action/ClubAction.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/api/action/ClubAction.kt
@@ -17,6 +17,7 @@ sealed class ClubAction : ContextAction() {
     @Serializable
     data class Add(
         val name: String,
+        val shortName: String,
         val location: String,
         val logoUrl: String,
     ) : ClubAction() {
@@ -40,6 +41,7 @@ sealed class ClubAction : ContextAction() {
     data class Update(
         val clubId: Int,
         val name: String,
+        val shortName: String,
         val location: String,
         val logoUrl: String,
     ) : ClubAction() {

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/api/action/ClubAction.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/api/action/ClubAction.kt
@@ -1,0 +1,68 @@
+package dk.spilpind.sms.api.action
+
+import dk.spilpind.sms.api.common.Action
+import dk.spilpind.sms.core.model.Context
+import kotlinx.serialization.Serializable
+
+/**
+ * All possible actions that can be made in relation to [Context.Club]
+ */
+@Serializable
+sealed class ClubAction : ContextAction() {
+    override val context: Context = Context.Club
+
+    /**
+     * Adds a new club. A successful response to this would be [ClubReaction.Added]
+     */
+    @Serializable
+    data class Add(
+        val name: String,
+        val location: String,
+        val logoUrl: String,
+    ) : ClubAction() {
+        override val action: Action = Action.Add
+    }
+
+    /**
+     * Removes the club with id [clubId]. The club must not be associated with any teams or alike. A successful response
+     * to this would be [ClubReaction.Removed]
+     */
+    @Serializable
+    data class Remove(val clubId: Int) : ClubAction() {
+        override val action: Action = Action.Remove
+    }
+
+    /**
+     * Updates the club with id [clubId] with the values provided. It is important to consider all values even though
+     * you're not allowed to change them, as for instance a value set to empty or null will be updated to that value
+     */
+    @Serializable
+    data class Update(
+        val clubId: Int,
+        val name: String,
+        val location: String,
+        val logoUrl: String,
+    ) : ClubAction() {
+        override val action: Action = Action.Update
+    }
+
+    /**
+     * Subscribes either to all clubs or the single club associated with [clubId] if specified. The subscription will be
+     * kept alive until the session is destroyed or [Unsubscribe] is called. Changes to the list will be sent via
+     * relevant [ClubReaction]s. A successful response to this would be [ClubReaction.Subscribed] followed by
+     * [ClubReaction.Updated]
+     */
+    @Serializable
+    data class Subscribe(val clubId: Int? = null) : ClubAction() {
+        override val action: Action = Action.Subscribe
+    }
+
+    /**
+     * Unsubscribes the socket from updates to the list of clubs, previously subscribed by [Subscribe]. A successful
+     * response to this would be [ClubReaction.Unsubscribed]
+     */
+    @Serializable
+    data class Unsubscribe(val clubId: Int? = null) : ClubAction() {
+        override val action: Action = Action.Unsubscribe
+    }
+}

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/api/action/ClubAction.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/api/action/ClubAction.kt
@@ -53,7 +53,7 @@ sealed class ClubAction : ContextAction() {
      * [ClubReaction.Updated]
      */
     @Serializable
-    data class Subscribe(val clubId: Int? = null) : ClubAction() {
+    data class Subscribe(val clubId: Int?) : ClubAction() {
         override val action: Action = Action.Subscribe
     }
 
@@ -62,7 +62,7 @@ sealed class ClubAction : ContextAction() {
      * response to this would be [ClubReaction.Unsubscribed]
      */
     @Serializable
-    data class Unsubscribe(val clubId: Int? = null) : ClubAction() {
+    data class Unsubscribe(val clubId: Int?) : ClubAction() {
         override val action: Action = Action.Unsubscribe
     }
 }

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/api/action/ClubReaction.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/api/action/ClubReaction.kt
@@ -1,0 +1,68 @@
+package dk.spilpind.sms.api.action
+
+import dk.spilpind.sms.core.model.Context
+import dk.spilpind.sms.api.common.Reaction
+import kotlinx.serialization.Serializable
+
+/**
+ * All possible reactions that can be made in relation to [Context.Club]
+ */
+@Serializable
+sealed class ClubReaction : ContextReaction() {
+    override val context: Context = Context.Club
+
+    /**
+     * Response to [ClubAction.Add]
+     */
+    @Serializable
+    data class Added(val club: Club) : ClubReaction() {
+        override val reaction: Reaction = Reaction.Added
+    }
+
+    /**
+     * Response to [ClubAction.Remove]
+     */
+    @Serializable
+    data class Removed(val clubId: Int) : ClubReaction() {
+        override val reaction: Reaction = Reaction.Removed
+    }
+
+    /**
+     * Response to changes in one or more of the clubs. If [allClubs] is false, only the listed clubs should be updated
+     * - if it's true, the entire list should be replaced
+     */
+    @Serializable
+    data class Updated(
+        val allClubs: Boolean,
+        val clubs: List<Club>
+    ) : ClubReaction() {
+        override val reaction: Reaction = Reaction.Updated
+    }
+
+    /**
+     * Response to [ClubAction.Subscribe]
+     */
+    @Serializable
+    class Subscribed : ClubReaction() {
+        override val reaction: Reaction = Reaction.Subscribed
+    }
+
+    /**
+     * Response to [ClubAction.Unsubscribe]
+     */
+    @Serializable
+    class Unsubscribed : ClubReaction() {
+        override val reaction: Reaction = Reaction.Unsubscribed
+    }
+
+    /**
+     * Represents a single club
+     */
+    @Serializable
+    data class Club(
+        val clubId: Int,
+        val name: String,
+        val location: String,
+        val logoUrl: String
+    )
+}

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/api/action/ClubReaction.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/api/action/ClubReaction.kt
@@ -62,6 +62,7 @@ sealed class ClubReaction : ContextReaction() {
     data class Club(
         val clubId: Int,
         val name: String,
+        val shortName: String,
         val location: String,
         val logoUrl: String
     )

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/api/action/TeamAction.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/api/action/TeamAction.kt
@@ -20,6 +20,7 @@ sealed class TeamAction : ContextAction() {
         val name: String,
         val shortName: String,
         val tournamentId: Int,
+        val clubId: Int? = null,
         val addAsCaptain: Boolean = false
     ) : TeamAction() {
         override val action: Action = Action.Add
@@ -43,6 +44,7 @@ sealed class TeamAction : ContextAction() {
         val teamId: Int,
         val name: String,
         val shortName: String,
+        val clubId: Int? = null,
     ) : TeamAction() {
         override val action: Action = Action.Update
     }

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/api/action/TeamReaction.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/api/action/TeamReaction.kt
@@ -88,6 +88,7 @@ sealed class TeamReaction : ContextReaction() {
         val teamId: Int,
         val name: String,
         val shortName: String,
-        val tournamentId: Int
+        val tournamentId: Int,
+        val clubId: Int?
     )
 }

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/core/Permissions.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/core/Permissions.kt
@@ -104,6 +104,34 @@ object Permissions {
     }
 
     /**
+     * Checks if the user (or "everyone" if null) can view clubs. Clubs are public information
+     */
+    fun User.Privileged?.canViewClub(): Boolean {
+        return true
+    }
+
+    /**
+     * Checks if the user can add any kind of club
+     */
+    fun User.Privileged.canAddClubs(): Boolean {
+        return hasSystemRole(UserRole.ContextRole.System.Admin)
+    }
+
+    /**
+     * Checks if the user can remove a club
+     */
+    fun User.Privileged.canRemoveClub(): Boolean {
+        return hasSystemRole(UserRole.ContextRole.System.Admin)
+    }
+
+    /**
+     * Checks if the user can edit a club
+     */
+    fun User.Privileged.canEditClub(): Boolean {
+        return hasSystemRole(UserRole.ContextRole.System.Admin)
+    }
+
+    /**
      * Checks if the user (or "everyone" if null) can view the specified [game] when associated with the specified
      * [tournament]
      */

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/core/Permissions.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/core/Permissions.kt
@@ -104,13 +104,6 @@ object Permissions {
     }
 
     /**
-     * Checks if the user (or "everyone" if null) can view clubs. Clubs are public information
-     */
-    fun User.Privileged?.canViewClub(): Boolean {
-        return true
-    }
-
-    /**
      * Checks if the user can add any kind of club
      */
     fun User.Privileged.canAddClubs(): Boolean {

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/Club.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/Club.kt
@@ -1,0 +1,26 @@
+package dk.spilpind.sms.core.model
+
+import kotlin.jvm.JvmInline
+
+/**
+ * Represents data about a club. A club groups teams under a shared identity and is described by a [name], a [location]
+ * (free-text, e.g. a city) and a [logoUrl] pointing at the club's logo
+ */
+data class Club(
+    val clubId: Id,
+    val name: String,
+    val location: String,
+    val logoUrl: String,
+) {
+
+    /**
+     * Id of a club. Can be used to reference a club without having to care about the remaining club data
+     */
+    @JvmInline
+    value class Id(override val identifier: Int) : ContextIdentifier, Comparable<Id> {
+
+        override fun compareTo(other: Id): Int =
+            identifier.compareTo(other.identifier)
+
+    }
+}

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/Club.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/Club.kt
@@ -3,12 +3,13 @@ package dk.spilpind.sms.core.model
 import kotlin.jvm.JvmInline
 
 /**
- * Represents data about a club. A club groups teams under a shared identity and is described by a [name], a [location]
- * (free-text, e.g. a city) and a [logoUrl] pointing at the club's logo
+ * Represents data about a club. A club groups teams under a shared identity and is described by a [name], a
+ * [shortName], a [location] (free-text, e.g. a city) and a [logoUrl] pointing at the club's logo
  */
 data class Club(
     val clubId: Id,
     val name: String,
+    val shortName: String,
     val location: String,
     val logoUrl: String,
 ) {

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/Context.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/Context.kt
@@ -19,6 +19,7 @@ enum class Context(val contextKey: String) {
     Game("game"),
     GameRules("gameRules"),
     GameGrouping("gameGrouping"),
+    Club("club"),
     Team("team"),
     TeamAdvancement("teamAdvancement"),
     Referee("referee"),

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/ModelHelper.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/ModelHelper.kt
@@ -214,6 +214,11 @@ object ModelHelper {
     fun Int.toPendingRequestId() = PendingRequest.Id(this)
 
     /**
+     * Creates a club id from the integer
+     */
+    fun Int.toClubId() = Club.Id(this)
+
+    /**
      * Creates a team id from the integer
      */
     fun Int.toTeamId() = Team.Id(this)

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/Team.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/Team.kt
@@ -12,6 +12,11 @@ sealed interface Team {
     val tournamentId: Tournament.Id
 
     /**
+     * The club the team belongs to, if any
+     */
+    val clubId: Club.Id?
+
+    /**
      * Id of a team. Can be used to reference a team without having to care about the remaining team data
      */
     @JvmInline
@@ -29,18 +34,21 @@ sealed interface Team {
         override val teamId: Id,
         override val name: String,
         override val shortName: String,
-        override val tournamentId: Tournament.Id
+        override val tournamentId: Tournament.Id,
+        override val clubId: Club.Id?
     ) : Team
 
     /**
-     * Like [Raw] with an actual representation of the tournament
+     * Like [Raw] with an actual representation of the tournament and club
      */
     data class Detailed(
         override val teamId: Id,
         override val name: String,
         override val shortName: String,
-        val tournament: Tournament
+        val tournament: Tournament,
+        val club: Club?
     ) : Team {
         override val tournamentId: Tournament.Id = tournament.tournamentId
+        override val clubId: Club.Id? = club?.clubId
     }
 }


### PR DESCRIPTION
Introduces a **club** as a first-class concept. A club groups teams under a shared identity and is described by a name, a location (free-text) and a URL to its logo. A team can optionally belong to a club.

## What's added

- **`Club` model** (`core/model/Club.kt`) — a `data class` with `name`, `location` and `logoUrl`, plus a nested `@JvmInline value class Id` (follows the `GameGrouping` pattern). Added `Int.toClubId()` to `ModelHelper`.
- **Team → club link** (`core/model/Team.kt`) — nullable `clubId: Club.Id?` on the interface and `Team.Raw`; `Team.Detailed` embeds the actual `Club?` and derives `clubId` from it (mirrors how `tournament` is embedded). No new `Team.Extended` variant.
- **Club API** — new `Context.Club`, `ClubAction` (`Add`, `Remove`, `Update`, `Subscribe`/`Unsubscribe` with optional `clubId`) and `ClubReaction` (`Added`, `Removed`, `Updated`, `Subscribed`, `Unsubscribed`, plus a nested `Club` DTO), wired into both serializer interceptors, with `canViewClub`/`canAddClubs`/`canRemoveClub`/`canEditClub` permission checks (admin-managed, publicly viewable) following the tournament checks.
- **Team API** — nullable `clubId` added to `TeamAction.Add`/`Update` and the `TeamReaction.Team` DTO.

## Commits

1. Add Club model
2. Link teams to clubs
3. Add club API
4. Expose club association on the team API

## Notes

- `name`, `location` and `logoUrl` are all required on the model; `logoUrl` can be relaxed to nullable later if needed. A single logo URL is used for now — large/small variants would be an additive change.
- The repo has no test sources, so verification was `compileCommonMainKotlinMetadata` after each commit (all green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GnxHXmrDg7TBAHNiWU4Fti)_