### PR TITLE
Let a game grouping own game rules

### DIFF
--- a/library/src/commonMain/kotlin/dk/spilpind/sms/api/action/GameGroupingAction.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/api/action/GameGroupingAction.kt
@@ -13,14 +13,16 @@ sealed class GameGroupingAction : ContextAction() {
 
     /**
      * Adds a new game grouping associated with the tournament identified by [tournamentId]. [level] describes how far
-     * into the tournament the grouping is, where a lower value is more important (e.g. 1 represents the final). A
-     * successful response to this would be [GameGroupingReaction.Added]
+     * into the tournament the grouping is, where a lower value is more important (e.g. 1 represents the final).
+     * [gameRulesId] optionally points to the game rules applied to games in the grouping that don't specify their own.
+     * A successful response to this would be [GameGroupingReaction.Added]
      */
     @Serializable
     data class Add(
         val tournamentId: Int,
         val name: String,
         val level: Int,
+        val gameRulesId: Int? = null,
     ) : GameGroupingAction() {
         override val action: Action = Action.Add
     }
@@ -44,6 +46,7 @@ sealed class GameGroupingAction : ContextAction() {
         val gameGroupingId: Int,
         val name: String,
         val level: Int,
+        val gameRulesId: Int?,
     ) : GameGroupingAction() {
         override val action: Action = Action.Update
     }

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/api/action/GameGroupingReaction.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/api/action/GameGroupingReaction.kt
@@ -64,5 +64,6 @@ sealed class GameGroupingReaction : ContextReaction() {
         val tournamentId: Int,
         val name: String,
         val level: Int,
+        val gameRulesId: Int?,
     )
 }

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/Game.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/Game.kt
@@ -19,8 +19,8 @@ sealed interface Game {
     val description: String
 
     /**
-     * Game rules attached directly to this game. When null, special rules might still apply via the tournament or, as a
-     * last resort, via [GameRules.Standard]
+     * Game rules attached directly to this game. When null, special rules might still apply via the game's
+     * [GameGrouping] or its tournament or, as a last resort, via [GameRules.Standard]
      */
     val gameRulesId: GameRules.Custom.Id?
 

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/Game.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/Game.kt
@@ -152,7 +152,9 @@ sealed interface Game {
                 is GameRules.Custom -> rules.gameRulesId
                 is GameRules.Standard -> null // TODO: Log if this happens
             }
-            GameRules.Effective.Source.Tournament, // The rules belong to the tournament, not this specific game
+            // The rules belong to the tournament or grouping, not this specific game
+            GameRules.Effective.Source.Tournament,
+            GameRules.Effective.Source.GameGrouping,
             GameRules.Effective.Source.Standard -> null
         }
     }

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/GameGrouping.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/GameGrouping.kt
@@ -12,6 +12,11 @@ data class GameGrouping(
     val tournamentId: Tournament.Id,
     val name: String,
     val level: Int,
+    /**
+     * Game rules applied to every game in the grouping that doesn't itself specify a [Game.gameRulesId]. When null, the
+     * grouping's tournament rules apply (or [GameRules.Standard] as a last resort)
+     */
+    val gameRulesId: GameRules.Custom.Id?,
 ) {
 
     /**

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/GameRules.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/GameRules.kt
@@ -65,6 +65,7 @@ sealed interface GameRules {
         enum class Source {
             Standard, // The official/standard rule set applies (rules == GameRules.Standard)
             Tournament, // Inherited from the game's tournament
+            GameGrouping, // Inherited from the game's grouping
             Game, // Attached directly to the game
         }
     }

--- a/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/Tournament.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/core/model/Tournament.kt
@@ -16,8 +16,8 @@ sealed interface Tournament {
     val endDate: LocalDate?
 
     /**
-     * Game rules applied to every game in the tournament that doesn't itself specify a [Game.gameRulesId]. When null,
-     * [GameRules.Standard] is used as a last resort
+     * Game rules applied to every game in the tournament that doesn't itself specify a [Game.gameRulesId] nor inherit
+     * rules from its [GameGrouping]. When null, [GameRules.Standard] is used as a last resort
      */
     val gameRulesId: GameRules.Custom.Id?
 


### PR DESCRIPTION
## Summary

Lets a `GameGrouping` own a set of `GameRules` the same way a `Tournament` already does, so that a game in a grouping inherits the grouping's rules when it doesn't specify its own. Rules now resolve in order of specificity: **Game → Grouping → Tournament → Standard**.

This is a contract change only. The new field and resolution *source* are added to the model and API; the actual server-side resolution chain (which still applies the old Game → Tournament → Standard order at runtime) is a follow-up.

## Changes

- **`GameRules.Effective.Source`** gains a `GameGrouping` value, ordered between `Tournament` and `Game` to encode the new fallback order.
- **`Game.Detailed.gameRulesId`** handles the new source in its exhaustive `when` (a game never owns grouping rules, so it resolves to `null`).
- **`GameGrouping`** gains `gameRulesId: GameRules.Custom.Id?`, mirroring `Tournament.gameRulesId`.
- **`GameGroupingAction.Add`** gets `gameRulesId: Int? = null` (back-compatible); **`Update`** gets `gameRulesId: Int?` (no default, matching its "all values explicit" contract).
- **`GameGroupingReaction.GameGrouping`** DTO exposes `gameRulesId: Int?` (id only, like the tournament reaction).
- KDoc on `Tournament.gameRulesId` and `Game.gameRulesId` updated to reflect that a grouping now sits ahead of the tournament in the resolution order.

## Verification

- `compileKotlinJvm` and `compileKotlinJs` both pass (covering both library consumers).
- No test sources exist in the library; the full `build` can't run in environments that block the Kotlin/Native distribution download, but native targets are unaffected by these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CF5rGBYRrTh2JAjBL64Jha