### PR TITLE
Add admin permissions for game grouping and team advancement mutations

### DIFF
--- a/library/src/commonMain/kotlin/dk/spilpind/sms/core/Permissions.kt
+++ b/library/src/commonMain/kotlin/dk/spilpind/sms/core/Permissions.kt
@@ -202,6 +202,27 @@ object Permissions {
     }
 
     /**
+     * Checks if the user can add a game grouping to the specified [tournament]
+     */
+    fun User.Privileged.canAddGameGrouping(tournament: Tournament): Boolean {
+        return !tournament.isLocked && hasSystemRole(UserRole.ContextRole.System.Admin)
+    }
+
+    /**
+     * Checks if the user can edit a game grouping in the specified [tournament]
+     */
+    fun User.Privileged.canEditGameGrouping(tournament: Tournament): Boolean {
+        return !tournament.isLocked && hasSystemRole(UserRole.ContextRole.System.Admin)
+    }
+
+    /**
+     * Checks if the user can remove a game grouping from the specified [tournament]
+     */
+    fun User.Privileged.canRemoveGameGrouping(tournament: Tournament): Boolean {
+        return !tournament.isLocked && hasSystemRole(UserRole.ContextRole.System.Admin)
+    }
+
+    /**
      * Checks if the user can create an invite such that another team can join the [game] in the specified [tournament]
      */
     fun User.Privileged.canCreateTeamJoinInviteForGame(game: Game, tournament: Tournament): Boolean {
@@ -270,6 +291,27 @@ object Permissions {
         }
         return hasSystemRole(UserRole.ContextRole.System.Admin)
                 || hasRole(role = UserRole.ContextRole.Team.Captain, contextId = teamId)
+    }
+
+    /**
+     * Checks if the user can add a team advancement to the specified [tournament]
+     */
+    fun User.Privileged.canAddTeamAdvancement(tournament: Tournament): Boolean {
+        return !tournament.isLocked && hasSystemRole(UserRole.ContextRole.System.Admin)
+    }
+
+    /**
+     * Checks if the user can edit a team advancement in the specified [tournament]
+     */
+    fun User.Privileged.canEditTeamAdvancement(tournament: Tournament): Boolean {
+        return !tournament.isLocked && hasSystemRole(UserRole.ContextRole.System.Admin)
+    }
+
+    /**
+     * Checks if the user can remove a team advancement from the specified [tournament]
+     */
+    fun User.Privileged.canRemoveTeamAdvancement(tournament: Tournament): Boolean {
+        return !tournament.isLocked && hasSystemRole(UserRole.ContextRole.System.Admin)
     }
 
     /**


### PR DESCRIPTION
## Summary

The tournament-structure feature added the `GameGrouping` and `TeamAdvancement` contexts with `Add`/`Update`/`Remove` actions, but the matching access-control functions in `Permissions.kt` were never added — so there was nothing to gate those mutations.

This adds six permission functions, mirroring the existing tournament-scoped mutation checks (e.g. `canEditGame`, `canRemoveTeam`): creating, editing and removing a grouping or an advancement is allowed **only for system admins, and only while the associated tournament is not locked**.

## Changes

In `core/Permissions.kt`, each new function returns `!tournament.isLocked && hasSystemRole(System.Admin)`:

- `canAddGameGrouping(tournament)`
- `canEditGameGrouping(tournament)`
- `canRemoveGameGrouping(tournament)`
- `canAddTeamAdvancement(tournament)`
- `canEditTeamAdvancement(tournament)`
- `canRemoveTeamAdvancement(tournament)`

There is intentionally no per-grouping/per-advancement role, so these are pure admin + lock checks taking only the `Tournament` (the caller resolves it from the model's `tournamentId`). View/subscribe gating is deliberately left for later.

## Verification

- `compileKotlinJvm` and `compileKotlinJs` both pass.
- No test sources exist in the library; the change is a pure `commonMain` addition with no new imports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CF5rGBYRrTh2JAjBL64Jha

---
_Generated by [Claude Code](https://claude.ai/code/session_01CF5rGBYRrTh2JAjBL64Jha)_